### PR TITLE
ログイン状態を維持する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,6 @@ module.exports = {
     'nuxt/no-cjs-in-config': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     'camelcase': 0,
-    'vue/no-v-html': false,
-    'no-console': process.env.NODE_ENV === 'production' ? 2 : 0  }
+    'vue/no-v-html': false
+  }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,6 @@ module.exports = {
     'nuxt/no-cjs-in-config': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     'camelcase': 0,
-    'vue/no-v-html': false
-  }
+    'vue/no-v-html': false,
+    'no-console': process.env.NODE_ENV === 'production' ? 2 : 0  }
 }

--- a/app/components/pages/signup.vue
+++ b/app/components/pages/signup.vue
@@ -26,9 +26,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 
-@Component({
-  components: {}
-})
+@Component
 export default class extends Vue {
   isChecked: boolean = false
 

--- a/app/middleware/authCookie.ts
+++ b/app/middleware/authCookie.ts
@@ -1,0 +1,10 @@
+import Cookies from 'universal-cookie'
+
+export default ({ req, store }: any) => {
+  if (process.browser) return
+
+  const cookies = new Cookies(req.headers.cookie)
+  const sessionId = cookies.get('sessionId')
+
+  if (sessionId) store.dispatch('qiita/saveSessionId', sessionId)
+}

--- a/app/middleware/redirect.ts
+++ b/app/middleware/redirect.ts
@@ -1,0 +1,13 @@
+export default function({ store, redirect, route }: any) {
+  const notRequiredAuthorization = ['/', '/signup', '/privacy', '/terms']
+
+  if (notRequiredAuthorization.includes(route.path)) return
+
+  if (store.getters['qiita/isLoggedIn'] && route.path === '/login') {
+    return redirect('/stocks/all')
+  }
+
+  if (!store.getters['qiita/isLoggedIn'] && route.path !== '/login') {
+    return redirect('/')
+  }
+}

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>認証が必要なページ(仮)</div>
+</template>

--- a/app/server/auth/oauth.ts
+++ b/app/server/auth/oauth.ts
@@ -35,6 +35,12 @@ router.get('/callback', async (req: Request, res: Response) => {
 
   try {
     const createAccountResponse = await qiita.fetchUser(req.query.code)
+    res.clearCookie('authorizationState')
+    res.cookie('sessionId', createAccountResponse._embedded.sessionId, {
+      path: '/',
+      httpOnly: true
+    })
+
     return res.status(200).json({ code: createAccountResponse.accountId })
   } catch (error) {
     return res

--- a/app/server/domain/auth.ts
+++ b/app/server/domain/auth.ts
@@ -8,44 +8,44 @@ import { clientId, clientSecret, apiUrlBase } from '../constants/envConstant.ts'
 const qiitaApi = QiitaApiFactory.create()
 const qiitaStockerApi = QiitaStockerpiFactory.create()
 
-interface IQiitaStockerErrorData {
+type QiitaStockerErrorData = {
   code: number
   message: string
 }
 
-export interface IQiitaStockerError extends AxiosError {
-  response: AxiosResponse<IQiitaStockerErrorData>
+export type IQiitaStockerError = AxiosError & {
+  response: AxiosResponse<QiitaStockerErrorData>
 }
 
-export interface IIssueAccessTokensRequest {
+export type IssueAccessTokensRequest = {
   client_id: string
   client_secret: string
   code: string
 }
 
-export interface IIssueAccessTokensResponse {
+export type IssueAccessTokensResponse = {
   client_id: string
   scopes: string[]
   token: string
 }
 
-export interface IFetchAuthenticatedUserRequest {
+export type FetchAuthenticatedUserRequest = {
   accessToken: string
 }
 
-export interface IFetchAuthenticatedUserResponse {
+export type FetchAuthenticatedUserResponse = {
   id: string
   permanent_id: string
 }
 
-export interface ICreateAccountRequest {
+export type CreateAccountRequest = {
   apiUrlBase: string
   qiitaAccountId: string
   permanentId: string
   accessToken: string
 }
 
-export interface ICreateAccountResponse {
+export type CreateAccountResponse = {
   accountId: string
   _embedded: { sessionId: string }
 }
@@ -80,33 +80,33 @@ export const createAuthorizationUrl = (authorizationState: string): string => {
  */
 export const fetchUser = async (
   authorizationCode: string
-): Promise<ICreateAccountResponse> => {
-  const issueAccessTokensRequest: IIssueAccessTokensRequest = {
+): Promise<CreateAccountResponse> => {
+  const issueAccessTokensRequest: IssueAccessTokensRequest = {
     client_id: clientId(),
     client_secret: clientSecret(),
     code: authorizationCode
   }
 
-  const issueAccessTokenResponse: IIssueAccessTokensResponse = await qiitaApi.issueAccessToken(
+  const issueAccessTokenResponse: IssueAccessTokensResponse = await qiitaApi.issueAccessToken(
     issueAccessTokensRequest
   )
 
-  const fetchAuthenticatedUserRequest: IFetchAuthenticatedUserRequest = {
+  const fetchAuthenticatedUserRequest: FetchAuthenticatedUserRequest = {
     accessToken: issueAccessTokenResponse.token
   }
 
-  const authenticatedUser: IFetchAuthenticatedUserResponse = await qiitaApi.fetchAuthenticatedUser(
+  const authenticatedUser: FetchAuthenticatedUserResponse = await qiitaApi.fetchAuthenticatedUser(
     fetchAuthenticatedUserRequest
   )
 
-  const createAccountRequest: ICreateAccountRequest = {
+  const createAccountRequest: CreateAccountRequest = {
     apiUrlBase: apiUrlBase(),
     qiitaAccountId: authenticatedUser.id,
     permanentId: authenticatedUser.permanent_id,
     accessToken: issueAccessTokenResponse.token
   }
 
-  const createAccountResponse: ICreateAccountResponse = await qiitaStockerApi.createAccount(
+  const createAccountResponse: CreateAccountResponse = await qiitaStockerApi.createAccount(
     createAccountRequest
   )
   return createAccountResponse

--- a/app/server/domain/qiitaApiinterface.ts
+++ b/app/server/domain/qiitaApiinterface.ts
@@ -1,15 +1,15 @@
 import {
-  IFetchAuthenticatedUserRequest,
-  IFetchAuthenticatedUserResponse,
-  IIssueAccessTokensRequest,
-  IIssueAccessTokensResponse
+  FetchAuthenticatedUserRequest,
+  FetchAuthenticatedUserResponse,
+  IssueAccessTokensRequest,
+  IssueAccessTokensResponse
 } from '@/server/domain/auth'
 
-export interface IQiitaApi {
+export type Api = {
   issueAccessToken(
-    request: IIssueAccessTokensRequest
-  ): Promise<IIssueAccessTokensResponse>
+    request: IssueAccessTokensRequest
+  ): Promise<IssueAccessTokensResponse>
   fetchAuthenticatedUser(
-    request: IFetchAuthenticatedUserRequest
-  ): Promise<IFetchAuthenticatedUserResponse>
+    request: FetchAuthenticatedUserRequest
+  ): Promise<FetchAuthenticatedUserResponse>
 }

--- a/app/server/domain/qiitaStockerApiinterface.ts
+++ b/app/server/domain/qiitaStockerApiinterface.ts
@@ -1,8 +1,8 @@
 import {
-  ICreateAccountRequest,
-  ICreateAccountResponse
+  CreateAccountRequest,
+  CreateAccountResponse
 } from '@/server/domain/auth'
 
-export interface IQiitaStockerApi {
-  createAccount(request: ICreateAccountRequest): Promise<ICreateAccountResponse>
+export type Api = {
+  createAccount(request: CreateAccountRequest): Promise<CreateAccountResponse>
 }

--- a/app/server/factroy/api/qiitaApiFactory.ts
+++ b/app/server/factroy/api/qiitaApiFactory.ts
@@ -1,8 +1,8 @@
 import QiitaApi from '../../repositories/qiitaApi'
-import { IQiitaApi } from '../../domain/qiitaApiinterface'
+import { Api } from '../../domain/qiitaApiinterface'
 
 export default class QiitaApiFactory {
-  static create(): IQiitaApi {
+  static create(): Api {
     return new QiitaApi()
   }
 }

--- a/app/server/factroy/api/qiitaStockerApiFactory.ts
+++ b/app/server/factroy/api/qiitaStockerApiFactory.ts
@@ -1,8 +1,8 @@
 import QiitaStockerApi from '../../repositories/qiitaStockerApi'
-import { IQiitaStockerApi } from '../../domain/qiitaStockerApiinterface'
+import { Api } from '../../domain/qiitaStockerApiinterface'
 
 export default class QiitaStockerApiFactory {
-  static create(): IQiitaStockerApi {
+  static create(): Api {
     return new QiitaStockerApi()
   }
 }

--- a/app/server/repositories/qiitaApi.ts
+++ b/app/server/repositories/qiitaApi.ts
@@ -1,22 +1,22 @@
 import axios, { AxiosResponse, AxiosError } from 'axios'
-import { IQiitaApi } from '@/server/domain/qiitaApiinterface'
+import { Api } from '@/server/domain/qiitaApiinterface'
 import {
-  IIssueAccessTokensRequest,
-  IIssueAccessTokensResponse,
-  IFetchAuthenticatedUserResponse,
-  IFetchAuthenticatedUserRequest
+  IssueAccessTokensRequest,
+  IssueAccessTokensResponse,
+  FetchAuthenticatedUserResponse,
+  FetchAuthenticatedUserRequest
 } from '@/server/domain/auth'
 
-export default class QiitaApi implements IQiitaApi {
+export default class QiitaApi implements Api {
   /**
    * @param request
    * @return {Promise<any | never>}
    */
   issueAccessToken(
-    request: IIssueAccessTokensRequest
-  ): Promise<IIssueAccessTokensResponse> {
+    request: IssueAccessTokensRequest
+  ): Promise<IssueAccessTokensResponse> {
     return axios
-      .post<IIssueAccessTokensResponse>(
+      .post<IssueAccessTokensResponse>(
         `https://qiita.com/api/v2/access_tokens`,
         request
       )
@@ -33,10 +33,10 @@ export default class QiitaApi implements IQiitaApi {
    * @return {Promise<any | never>}
    */
   fetchAuthenticatedUser(
-    request: IFetchAuthenticatedUserRequest
-  ): Promise<IFetchAuthenticatedUserResponse> {
+    request: FetchAuthenticatedUserRequest
+  ): Promise<FetchAuthenticatedUserResponse> {
     return axios
-      .get<IFetchAuthenticatedUserResponse>(
+      .get<FetchAuthenticatedUserResponse>(
         `https://qiita.com/api/v2/authenticated_user`,
         {
           headers: { Authorization: `Bearer ${request.accessToken}` }

--- a/app/server/repositories/qiitaStockerApi.ts
+++ b/app/server/repositories/qiitaStockerApi.ts
@@ -1,17 +1,15 @@
 import axios, { AxiosResponse } from 'axios'
-import { IQiitaStockerApi } from '@/server/domain/qiitaStockerApiinterface'
+import { Api } from '@/server/domain/qiitaStockerApiinterface'
 import {
-  ICreateAccountRequest,
-  ICreateAccountResponse,
+  CreateAccountRequest,
+  CreateAccountResponse,
   IQiitaStockerError
 } from '@/server/domain/auth'
 
-export default class QiitaStockerApi implements IQiitaStockerApi {
-  createAccount(
-    request: ICreateAccountRequest
-  ): Promise<ICreateAccountResponse> {
+export default class QiitaStockerApi implements Api {
+  createAccount(request: CreateAccountRequest): Promise<CreateAccountResponse> {
     return axios
-      .post<ICreateAccountResponse>(
+      .post<CreateAccountResponse>(
         `${request.apiUrlBase}/api/accounts`,
         {
           qiitaAccountId: request.qiitaAccountId,

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,0 +1,1 @@
+export interface RootState {}

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -1,0 +1,28 @@
+import { GetterTree, ActionTree, MutationTree } from 'vuex'
+import { RootState } from '@/store'
+
+export interface IQiitaState {
+  sessionId: string
+}
+
+export const state = (): IQiitaState => ({
+  sessionId: ''
+})
+
+export const getters: GetterTree<IQiitaState, RootState> = {
+  isLoggedIn: (state): boolean => {
+    return !!state.sessionId
+  }
+}
+
+export const mutations: MutationTree<IQiitaState> = {
+  saveSessionId: (state, sessionId: string) => {
+    state.sessionId = sessionId
+  }
+}
+
+export const actions: ActionTree<IQiitaState, RootState> = {
+  saveSessionId: ({ commit }, sessionId: string) => {
+    commit('saveSessionId', sessionId)
+  }
+}

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -1,27 +1,27 @@
 import { GetterTree, ActionTree, MutationTree } from 'vuex'
 import { RootState } from '@/store'
 
-export interface IQiitaState {
+export type QiitaState = {
   sessionId: string
 }
 
-export const state = (): IQiitaState => ({
+export const state = (): QiitaState => ({
   sessionId: ''
 })
 
-export const getters: GetterTree<IQiitaState, RootState> = {
+export const getters: GetterTree<QiitaState, RootState> = {
   isLoggedIn: (state): boolean => {
     return !!state.sessionId
   }
 }
 
-export const mutations: MutationTree<IQiitaState> = {
+export const mutations: MutationTree<QiitaState> = {
   saveSessionId: (state, sessionId: string) => {
     state.sessionId = sessionId
   }
 }
 
-export const actions: ActionTree<IQiitaState, RootState> = {
+export const actions: ActionTree<QiitaState, RootState> = {
   saveSessionId: ({ commit }, sessionId: string) => {
     commit('saveSessionId', sessionId)
   }

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+  interface Process {
+    server: boolean
+    browser: boolean
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,9 @@ const pkg = require('./package')
 const nuxtConfig: NuxtConfiguration = {
   mode: 'universal',
   srcDir: 'app',
+  router: {
+    middleware: ['authCookie', 'redirect']
+  },
   /*
    ** Headers of the page
    */

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cross-env": "^5.2.0",
     "express": "^4.16.4",
     "nuxt": "^2.6.1",
+    "universal-cookie": "^3.1.0",
     "uuid": "^3.3.2",
     "vue-property-decorator": "^8.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nuxtjs/eslint-config": "^0.0.1",
     "@types/cookie-parser": "^1.4.1",
     "@types/jest": "^24.0.11",
+    "@types/universal-cookie": "^2.2.0",
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
     "@typescript-eslint/parser": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,6 +1250,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/cookie@^0.3.1":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.2.tgz#453f4b14b25da6a8ea4494842dedcbf0151deef9"
+  integrity sha512-aHQA072E10/8iUQsPH7mQU/KUyQBZAGzTVRCUvnSz8mSvbrYsP4xEO2RSA0Pjltolzi0j8+8ixrm//Hr4umPzw==
+
 "@types/etag@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/etag/-/etag-1.8.0.tgz#37f0b1f3ea46da7ae319bbedb607e375b4c99f7e"
@@ -1321,6 +1326,11 @@
   version "11.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
   integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+
+"@types/object-assign@^4.0.30":
+  version "4.0.30"
+  resolved "https://registry.yarnpkg.com/@types/object-assign/-/object-assign-4.0.30.tgz#8949371d5a99f4381ee0f1df0a9b7a187e07e652"
+  integrity sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=
 
 "@types/optimize-css-assets-webpack-plugin@^1.3.4":
   version "1.3.4"
@@ -9546,6 +9556,16 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universal-cookie@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-3.1.0.tgz#a16964ccb16cf8fa463bda1ebe86482945339ad8"
+  integrity sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==
+  dependencies:
+    "@types/cookie" "^0.3.1"
+    "@types/object-assign" "^4.0.30"
+    cookie "^0.3.1"
+    object-assign "^4.1.0"
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,6 +1397,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/universal-cookie@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/universal-cookie/-/universal-cookie-2.2.0.tgz#36fba91f8a8c64cfd109520d15ec2ec3f32561e9"
+  integrity sha512-fNgC782wfxAZZLDfFM70AgDzYh/VX7tH8NPl/fYNgoseXVLTg+vQf2zhzbWDlJiO0fKXwCL54HOKtXpjcV5C+A==
+
 "@types/uuid@^3.4.4":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/7

# Doneの定義
- クライアント、サーバーサイドの両方においてログイン状態が維持できること
- ダミーの認証ページを作成して、上記を確認できること

# 変更点概要

## 仕様的変更点概要
仮の認証ページ`http://127.0.0.1:8080/stocks/all`を作成。
認証済みの場合のみ`/stocks/all`に遷移し、認証されていない場合は`/`にリダイレクトされる処理を追加。

## 技術的変更点概要
ログイン状態を保持するために、Vuexのモジュールを追加。
発行されたセッションIDをCookieに保持し、ミドルウェア(app/middleware/authCookie.ts)でVuexのストアに保存している。
またログイン状態によって、リダイレクトする処理を追加(app/middleware/redirect.ts)し、認証されていない場合は、認証が必要なページに遷移できないように制御している。

今回のIssueとは関係ないが、下記のリファクタリングを実施。
TypeScriptの`Interface`を使用している箇所を`Type Alias`に変更