### PR TITLE
vuex-type-helperを導入する

### DIFF
--- a/app/components/pages/cancel/index.vue
+++ b/app/components/pages/cancel/index.vue
@@ -12,11 +12,17 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
+import { mapActions } from '@/store/qiita'
 
-@Component
+@Component({
+  methods: {
+    ...mapActions(['cancelAction'])
+  }
+})
 export default class extends Vue {
+  cancelAction!: () => void
   async cancel() {
-    await this.$store.dispatch('qiita/cancel')
+    await this.cancelAction()
     this.$router.replace({ path: 'cancel/complete' })
   }
 }

--- a/app/middleware/authCookie.ts
+++ b/app/middleware/authCookie.ts
@@ -6,5 +6,6 @@ export default ({ req, store }: any) => {
   const cookies = new Cookies(req.headers.cookie)
   const sessionId = cookies.get('sessionId')
 
-  if (sessionId) store.dispatch('qiita/saveSessionId', sessionId)
+  if (sessionId)
+    store.dispatch('qiita/saveSessionIdAction', { sessionId: sessionId })
 }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -1,35 +1,69 @@
-import { GetterTree, ActionTree, MutationTree } from 'vuex'
-import { RootState } from '@/store'
+import { createNamespacedHelpers } from 'vuex'
 import { cancelAccount } from '@/domain/domain'
+import { DefineGetters, DefineMutations, DefineActions } from 'vuex-type-helper'
 
 export type QiitaState = {
   sessionId: string
+}
+
+export interface QiitaGetters {
+  isLoggedIn: boolean
+}
+
+export interface QiitaMutations {
+  saveSessionId: {
+    sessionId: string
+  }
+}
+
+export interface QiitaActions {
+  saveSessionIdAction: {
+    sessionId: string
+  }
+  cancelAction: {}
 }
 
 export const state = (): QiitaState => ({
   sessionId: ''
 })
 
-export const getters: GetterTree<QiitaState, RootState> = {
+export const getters: DefineGetters<QiitaGetters, QiitaState> = {
   isLoggedIn: (state): boolean => {
     return !!state.sessionId
   }
 }
 
-export const mutations: MutationTree<QiitaState> = {
-  saveSessionId: (state, sessionId: string) => {
+export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
+  saveSessionId: (state, { sessionId }) => {
     state.sessionId = sessionId
   }
 }
 
-export const actions: ActionTree<QiitaState, RootState> = {
-  saveSessionId: ({ commit }, sessionId: string) => {
+export const actions: DefineActions<
+  QiitaActions,
+  QiitaState,
+  QiitaMutations,
+  QiitaGetters
+> = {
+  saveSessionIdAction: ({ commit }, sessionId) => {
     commit('saveSessionId', sessionId)
   },
-  cancel: async ({ commit }) => {
+  cancelAction: async ({ commit }) => {
     try {
       await cancelAccount()
-      commit('saveSessionId', '')
+      commit('saveSessionId', { sessionId: '' })
     } catch (error) {}
   }
 }
+
+export const {
+  mapActions,
+  mapGetters,
+  mapMutations,
+  mapState
+} = createNamespacedHelpers<
+  QiitaState,
+  QiitaGetters,
+  QiitaMutations,
+  QiitaActions
+>('qiita')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "nuxt": "^2.6.1",
     "universal-cookie": "^4.0.0",
     "uuid": "^3.3.2",
-    "vue-property-decorator": "^8.1.1"
+    "vue-property-decorator": "^8.1.1",
+    "vuex-type-helper": "^1.2.2"
   },
   "devDependencies": {
     "@nekonomokochan/aws-env-creator": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10110,6 +10110,11 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuex-type-helper@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/vuex-type-helper/-/vuex-type-helper-1.2.2.tgz#a0d4d1d440bbb64df5b469bc65001935372b1a73"
+  integrity sha512-s8SKx952+eKyfgne2i74rup2u6vEfV12rFO0o43XpmU2SPtprnx+9Dm0g3eWiKmfoiCLkVhUshwwFb9pfo7LpQ==
+
 vuex@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.0.tgz#634b81515cf0cfe976bd1ffe9601755e51f843b9"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/27

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/27 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
`vuex-type-helper`を追加し、VuexのStoreに型の定義を追加。

# 補足情報
`vuex-type-helper`の`Dispatcher`を利用してVuexのActionを呼び出したかったが、モジュールモードに対応しておらず、実現することができなかった。
関連Issue：https://github.com/ktsn/vuex-type-helper/issues/2 

下記を実行するとActionを実行できずにエラーとなる。
````
<script lang="ts">
import { Component, Vue } from 'vue-property-decorator'
import { QiitaActions } from '@/store/qiita'
import { Dispatcher } from 'vuex-type-helper'

@Component
export default class extends Vue {
  async cancel() {
    await this.$store.dispatch<Dispatcher<QiitaActions>>({ type: 'cancel' })
    this.$router.replace({ path: 'cancel/complete' })
  }
}
</script>