### PR TITLE
エラーの表示処理を作成する

### DIFF
--- a/app/components/pages/cancel/index.vue
+++ b/app/components/pages/cancel/index.vue
@@ -22,8 +22,17 @@ import { mapActions } from '@/store/qiita'
 export default class extends Vue {
   cancelAction!: () => void
   async cancel() {
-    await this.cancelAction()
-    this.$router.replace({ path: 'cancel/complete' })
+    try {
+      await this.cancelAction()
+      this.$router.replace({ path: 'cancel/complete' })
+    } catch (e) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: e.response.data.message
+        }
+      })
+    }
   }
 }
 </script>

--- a/app/components/pages/cancel/index.vue
+++ b/app/components/pages/cancel/index.vue
@@ -25,11 +25,11 @@ export default class extends Vue {
     try {
       await this.cancelAction()
       this.$router.replace({ path: 'cancel/complete' })
-    } catch (e) {
+    } catch (error) {
       this.$router.push({
         name: 'original_error',
         params: {
-          message: e.response.data.message
+          message: error.message
         }
       })
     }

--- a/app/components/pages/error.vue
+++ b/app/components/pages/error.vue
@@ -1,0 +1,25 @@
+<template>
+  <main>
+    <div class="container has-text-centered">
+      <h1 class="title">Error</h1>
+      <h2 class="subtitle">{{ error.message }}</h2>
+      <nuxt-link to="/">TOPページへ</nuxt-link>
+    </div>
+  </main>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+
+@Component
+export default class extends Vue {
+  @Prop()
+  error!: Object
+}
+</script>
+
+<style scoped>
+.subtitle {
+  padding-top: 1rem;
+}
+</style>

--- a/app/components/pages/error.vue
+++ b/app/components/pages/error.vue
@@ -2,7 +2,7 @@
   <main>
     <div class="container has-text-centered">
       <h1 class="title">Error</h1>
-      <h2 class="subtitle">{{ error.message }}</h2>
+      <h2 class="subtitle">{{ message }}</h2>
       <nuxt-link to="/">TOPページへ</nuxt-link>
     </div>
   </main>
@@ -14,7 +14,7 @@ import { Component, Vue, Prop } from 'nuxt-property-decorator'
 @Component
 export default class extends Vue {
   @Prop()
-  error!: Object
+  message!: string
 }
 </script>
 

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -24,8 +24,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 import SideMenu from '@/components/SideMenu.vue'
 import StockList from '@/components/StockList.vue'
 import Loading from '@/components/Loading.vue'
-import { mapGetters, mapActions } from '@/store/qiita'
-import { Page } from '@/domain/domain'
+import { mapGetters } from '@/store/qiita'
 
 @Component({
   components: {
@@ -35,16 +34,7 @@ import { Page } from '@/domain/domain'
   },
   computed: {
     ...mapGetters(['uncategorizedStocks', 'isCategorizing', 'isLoading'])
-  },
-  methods: {
-    ...mapActions(['fetchUncategorizedStocks'])
   }
 })
-export default class extends Vue {
-  fetchUncategorizedStocks!: (page?: Page) => void
-
-  async created() {
-    await this.fetchUncategorizedStocks()
-  }
-}
+export default class extends Vue {}
 </script>

--- a/app/domain/domain.ts
+++ b/app/domain/domain.ts
@@ -1,6 +1,16 @@
 import QiitaStockApiFactory from '@/factory/qiitaStockApi'
+import { AxiosError, AxiosResponse } from 'axios'
 
 const api = QiitaStockApiFactory.create()
+
+type QiitaStockerErrorData = {
+  code: number
+  message: string
+}
+
+export type QiitaStockerError = AxiosError & {
+  response: AxiosResponse<QiitaStockerErrorData>
+}
 
 export type Page = {
   page: number

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <Error :error="error" />
+  <Error :message="message" />
 </template>
 
 <script lang="ts">
@@ -13,6 +13,12 @@ import Error from '@/components/pages/error.vue'
 })
 export default class extends Vue {
   @Prop()
-  error?: Object
+  error!: { statusCode: string; message: string }
+
+  message: string = ''
+
+  created() {
+    this.message = this.error.message
+  }
 }
 </script>

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -1,0 +1,18 @@
+<template>
+  <Error :error="error" />
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import Error from '@/components/pages/error.vue'
+
+@Component({
+  components: {
+    Error
+  }
+})
+export default class extends Vue {
+  @Prop()
+  error?: Object
+}
+</script>

--- a/app/pages/error.vue
+++ b/app/pages/error.vue
@@ -1,0 +1,22 @@
+<template>
+  <Error :message="errorMessage" />
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import Error from '@/components/pages/error.vue'
+
+@Component({
+  components: {
+    Error
+  }
+})
+export default class extends Vue {
+  @Prop()
+  errorMessage!: string
+
+  mounted() {
+    console.log(`🐑🐑🐑 ${this.errorMessage}`)
+  }
+}
+</script>

--- a/app/pages/error.vue
+++ b/app/pages/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <Error :message="errorMessage" />
+  <Error :message="message" />
 </template>
 
 <script lang="ts">
@@ -13,10 +13,6 @@ import Error from '@/components/pages/error.vue'
 })
 export default class extends Vue {
   @Prop()
-  errorMessage!: string
-
-  mounted() {
-    console.log(`🐑🐑🐑 ${this.errorMessage}`)
-  }
+  message!: string
 }
 </script>

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -20,7 +20,10 @@ export default class extends Vue {
     try {
       await store.dispatch('qiita/fetchUncategorizedStocks')
     } catch (e) {
-      error({ statusCode: '500', message: 'test' })
+      error({
+        statusCode: e.response.data.code,
+        message: e.response.data.message
+      })
     }
   }
 }

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
 import All from '@/components/pages/stocks/all.vue'
+import { NuxtContext } from '@/types'
 
 @Component({
   layout: 'stocks',
@@ -14,5 +15,13 @@ import All from '@/components/pages/stocks/all.vue'
     All
   }
 })
-export default class extends Vue {}
+export default class extends Vue {
+  async fetch({ store, error }: NuxtContext) {
+    try {
+      await store.dispatch('qiita/fetchUncategorizedStocks')
+    } catch (e) {
+      error({ statusCode: '500', message: 'test' })
+    }
+  }
+}
 </script>

--- a/app/repositories/api.ts
+++ b/app/repositories/api.ts
@@ -1,11 +1,11 @@
-import axios, { AxiosError, AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import {
+  QiitaStockerError,
   QiitaStockApi,
   Page,
   FetchUncategorizedStockRequest,
   FetchUncategorizedStockResponse
 } from '@/domain/domain'
-import { QiitaStockerError } from '@/server/domain/auth'
 
 export default class Api implements QiitaStockApi {
   /**
@@ -17,8 +17,8 @@ export default class Api implements QiitaStockApi {
       .then(() => {
         return Promise.resolve()
       })
-      .catch((axiosError: AxiosError) => {
-        return Promise.reject(axiosError)
+      .catch((axiosError: QiitaStockerError) => {
+        return Promise.reject(axiosError.response.data)
       })
   }
 

--- a/app/server/api/qiita.ts
+++ b/app/server/api/qiita.ts
@@ -11,8 +11,8 @@ router.get('/cancel', async (req: Request, res: Response) => {
     return res.status(204).json()
   } catch (error) {
     return res
-      .status(400)
-      .send()
+      .status(error.response.status)
+      .json(error.response.data)
       .end()
   }
 })

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -103,16 +103,18 @@ export const actions: DefineActions<
   saveSessionIdAction: ({ commit }, sessionId) => {
     commit('saveSessionId', sessionId)
   },
-  cancelAction: async ({ commit }) => {
+  cancelAction: async ({ commit }): Promise<void> => {
     try {
       await cancelAccount()
       commit('saveSessionId', { sessionId: '' })
-    } catch (error) {}
+    } catch (error) {
+      return Promise.reject(error)
+    }
   },
   fetchUncategorizedStocks: async (
     { commit, state },
     page: Page = { page: state.currentPage, perPage: 20, relation: '' }
-  ): Promise<any> => {
+  ): Promise<void> => {
     try {
       const fetchStockRequest: FetchUncategorizedStockRequest = {
         apiUrlBase: EnvConstant.apiUrlBase(),
@@ -140,8 +142,8 @@ export const actions: DefineActions<
       commit('setIsLoading', { isLoading: false })
       commit('savePaging', { paging: response.paging })
       commit('saveCurrentPage', { currentPage: page.page })
-    } catch (e) {
-      return Promise.reject(e)
+    } catch (error) {
+      return Promise.reject(error)
     }
   }
 }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -112,7 +112,7 @@ export const actions: DefineActions<
   fetchUncategorizedStocks: async (
     { commit, state },
     page: Page = { page: state.currentPage, perPage: 20, relation: '' }
-  ) => {
+  ): Promise<any> => {
     try {
       const fetchStockRequest: FetchUncategorizedStockRequest = {
         apiUrlBase: EnvConstant.apiUrlBase(),
@@ -140,7 +140,9 @@ export const actions: DefineActions<
       commit('setIsLoading', { isLoading: false })
       commit('savePaging', { paging: response.paging })
       commit('saveCurrentPage', { currentPage: page.page })
-    } catch (error) {}
+    } catch (e) {
+      return Promise.reject(e)
+    }
   }
 }
 

--- a/app/types/index.d.ts
+++ b/app/types/index.d.ts
@@ -3,13 +3,6 @@ import { Route } from 'vue-router'
 import { Store } from 'vuex'
 import { MetaInfo } from 'vue-meta'
 
-declare namespace NodeJS {
-  interface Process {
-    server: boolean
-    browser: boolean
-  }
-}
-
 interface NuxtContext {
   isClient: boolean
   isServer: boolean

--- a/app/types/node.d.ts
+++ b/app/types/node.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+  interface Process {
+    server: boolean
+    browser: boolean
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,15 @@ const nuxtConfig: NuxtConfiguration = {
     apiUrlBase: process.env.API_URL_BASE || 'http://localhost:3000'
   },
   router: {
-    middleware: ['authCookie', 'redirect']
+    middleware: ['authCookie', 'redirect'],
+    extendRoutes(routes: any, resolve) {
+      routes.push({
+        name: 'original_error',
+        path: '/error',
+        props: true,
+        component: resolve(__dirname, 'app/pages/error.vue')
+      })
+    }
   },
   /*
    ** Headers of the page

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Mindexer Nuxt.js project",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development NUXT_HOST=127.0.0.1 NUXT_PORT=8080 nodemon",
+    "dev": "cross-env NODE_ENV=development NUXT_HOST=127.0.0.1 NUXT_PORT=8080 nuxt",
+    "dev:server": "cross-env NODE_ENV=development NUXT_HOST=127.0.0.1 NUXT_PORT=8080 nodemon",
     "build": "nuxt build",
     "start": "cross-env NODE_ENV=production node app/server/index.js",
     "generate": "nuxt generate",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/32

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/32 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
ストック一覧取得時と退会処理のエラー表示処理を作成。

## 技術的変更点概要
エラーページは2画面作成し、下記の通り表示する。
- `app/layouts/error.vue`
 -> ページコンポーネントのfetchなどでエラーになった場合に表示
 -> [エラー処理](https://ja.nuxtjs.org/guide/async-data/#%E3%82%A8%E3%83%A9%E3%83%BC%E5%87%A6%E7%90%86)

- `app/pages/error.vue`
  -> ブラウザ上の処理でエラーになった場合に表示
  -> `nuxt.config.ts`にて、router プロパティでpropsを受け取れるように設定している

Issueとは直接関係ないが、下記のリファクタリングを行なった。
- ストック取得APIへのリクエストを`app/components/pages/stocks/all.vue`の`created()`からページコンポーネントの`fetch()`に移動