### PR TITLE
ログアウト処理を作成する 

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -25,7 +25,7 @@
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">メニュー</a>
               <div class="navbar-dropdown is-right">
-                <nuxt-link class="navbar-item" to="/stocks"
+                <nuxt-link class="navbar-item" to="/stocks/all"
                   >ストック一覧</nuxt-link
                 >
                 <a class="navbar-item" @click="logout">ログアウト</a>
@@ -40,11 +40,37 @@
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
-@Component
+import { mapGetters, mapActions } from '@/store/qiita'
+
+@Component({
+  computed: {
+    ...mapGetters(['isLoggedIn'])
+  },
+  methods: {
+    ...mapActions(['logoutAction'])
+  }
+})
 export default class AppHeader extends Vue {
-  // TODO Storeの値に変更する
-  isLoggedIn: boolean = false
+  logoutAction!: () => void
   isMenuActive: boolean = false
+
+  menuToggle() {
+    this.isMenuActive = !this.isMenuActive
+  }
+
+  async logout() {
+    try {
+      await this.logoutAction()
+      this.$router.replace({ path: '/' })
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
+  }
 }
 </script>
 

--- a/app/domain/domain.ts
+++ b/app/domain/domain.ts
@@ -51,6 +51,7 @@ export type FetchUncategorizedStockResponse = {
 
 export type QiitaStockApi = {
   cancelAccount(): Promise<void>
+  logout(): Promise<void>
   fetchUncategorizedStocks(
     request: FetchUncategorizedStockRequest
   ): Promise<FetchUncategorizedStockResponse>
@@ -58,6 +59,10 @@ export type QiitaStockApi = {
 
 export const cancelAccount = async () => {
   await api.cancelAccount()
+}
+
+export const logout = async () => {
+  await api.logout()
 }
 
 export const fetchUncategorizedStocks = (

--- a/app/repositories/api.ts
+++ b/app/repositories/api.ts
@@ -22,6 +22,24 @@ export default class Api implements QiitaStockApi {
       })
   }
 
+  /**
+   * @return {Promise<void | never>}
+   */
+  logout(): Promise<void> {
+    return axios
+      .get('/api/logout')
+      .then(() => {
+        return Promise.resolve()
+      })
+      .catch((axiosError: QiitaStockerError) => {
+        return Promise.reject(axiosError.response.data)
+      })
+  }
+
+  /**
+   * @param request
+   * @return {Promise<FetchUncategorizedStockResponse | never>}
+   */
   fetchUncategorizedStocks(
     request: FetchUncategorizedStockRequest
   ): Promise<FetchUncategorizedStockResponse> {

--- a/app/server/api/qiita.ts
+++ b/app/server/api/qiita.ts
@@ -17,4 +17,17 @@ router.get('/cancel', async (req: Request, res: Response) => {
   }
 })
 
+router.get('/logout', async (req: Request, res: Response) => {
+  try {
+    await qiita.logout(req.cookies[auth.COOKIE_SESSION_ID])
+    res.clearCookie(auth.COOKIE_SESSION_ID)
+    return res.status(204).json()
+  } catch (error) {
+    return res
+      .status(error.response.status)
+      .json(error.response.data)
+      .end()
+  }
+})
+
 export default router

--- a/app/server/auth/oauth.ts
+++ b/app/server/auth/oauth.ts
@@ -77,7 +77,7 @@ router.get('/callback', async (req: Request, res: Response) => {
       httpOnly: true
     })
 
-    return res.status(200).json({ code: sessionId })
+    return res.redirect(auth.redirectAppUrl())
   } catch (error) {
     return res
       .status(400)

--- a/app/server/constants/envConstant.ts
+++ b/app/server/constants/envConstant.ts
@@ -15,3 +15,9 @@ export const apiUrlBase = (): string => {
     ? process.env.API_URL_BASE
     : ''
 }
+
+export const appUrl = (): string => {
+  return typeof process.env.APP_URL === 'string'
+    ? process.env.APP_URL
+    : ''
+}

--- a/app/server/domain/auth.ts
+++ b/app/server/domain/auth.ts
@@ -3,7 +3,12 @@ import uuid from 'uuid'
 import { AxiosResponse, AxiosError } from 'axios'
 import QiitaApiFactory from '../factroy/api/qiitaApiFactory'
 import QiitaStockerApiFactory from '../factroy/api/qiitaStockerApiFactory'
-import { clientId, clientSecret, apiUrlBase } from '../constants/envConstant'
+import {
+  clientId,
+  clientSecret,
+  apiUrlBase,
+  appUrl
+} from '../constants/envConstant'
 
 const qiitaApi = QiitaApiFactory.create()
 const qiitaStockerApi = QiitaStockerApiFactory.create()
@@ -88,6 +93,10 @@ export const createAuthorizationUrl = (authorizationState: string): string => {
       state: authorizationState
     }
   })
+}
+
+export const redirectAppUrl = (): string => {
+  return `${appUrl()}/stocks/all`
 }
 
 /**

--- a/app/server/domain/qiita.ts
+++ b/app/server/domain/qiita.ts
@@ -7,6 +7,10 @@ export type CancelAccountRequest = {
   apiUrlBase: string
   sessionId: string
 }
+export type LogoutRequest = {
+  apiUrlBase: string
+  sessionId: string
+}
 
 export const cancelAccount = (sessionId: string): Promise<void> => {
   const cancelAccountRequest: CancelAccountRequest = {
@@ -15,4 +19,13 @@ export const cancelAccount = (sessionId: string): Promise<void> => {
   }
 
   return qiitaStockerApi.cancelAccount(cancelAccountRequest)
+}
+
+export const logout = (sessionId: string): Promise<void> => {
+  const logoutRequest: LogoutRequest = {
+    apiUrlBase: apiUrlBase(),
+    sessionId: sessionId
+  }
+
+  return qiitaStockerApi.logout(logoutRequest)
 }

--- a/app/server/domain/qiitaStockerApiInterface.ts
+++ b/app/server/domain/qiitaStockerApiInterface.ts
@@ -5,7 +5,7 @@ import {
   IssueLoginSessionResponse
 } from '@/server/domain/auth'
 
-import { CancelAccountRequest } from '@/server/domain/qiita'
+import { CancelAccountRequest, LogoutRequest } from '@/server/domain/qiita'
 
 export type Api = {
   createAccount(request: CreateAccountRequest): Promise<CreateAccountResponse>
@@ -13,4 +13,5 @@ export type Api = {
     request: IssueLoginSessionRequest
   ): Promise<IssueLoginSessionResponse>
   cancelAccount(request: CancelAccountRequest): Promise<void>
+  logout(request: LogoutRequest): Promise<void>
 }

--- a/app/server/repositories/qiitaStockerApi.ts
+++ b/app/server/repositories/qiitaStockerApi.ts
@@ -7,7 +7,7 @@ import {
   IssueLoginSessionRequest,
   IssueLoginSessionResponse
 } from '@/server/domain/auth'
-import { CancelAccountRequest } from '@/server/domain/qiita'
+import { CancelAccountRequest, LogoutRequest } from '@/server/domain/qiita'
 
 export default class QiitaStockerApi implements Api {
   createAccount(request: CreateAccountRequest): Promise<CreateAccountResponse> {
@@ -61,6 +61,21 @@ export default class QiitaStockerApi implements Api {
   cancelAccount(request: CancelAccountRequest): Promise<void> {
     return axios
       .delete(`${request.apiUrlBase}/api/accounts`, {
+        headers: {
+          Authorization: `Bearer ${request.sessionId}`
+        }
+      })
+      .then(() => {
+        return Promise.resolve()
+      })
+      .catch((axiosError: QiitaStockerError) => {
+        return Promise.reject(axiosError)
+      })
+  }
+
+  logout(request: LogoutRequest): Promise<void> {
+    return axios
+      .delete(`${request.apiUrlBase}/api/login-sessions`, {
         headers: {
           Authorization: `Bearer ${request.sessionId}`
         }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -1,6 +1,7 @@
 import { createNamespacedHelpers } from 'vuex'
 import {
   cancelAccount,
+  logout,
   UncategorizedStock,
   fetchUncategorizedStocks,
   FetchUncategorizedStockRequest,
@@ -50,6 +51,7 @@ export interface QiitaActions {
   }
   cancelAction: {}
   fetchUncategorizedStocks: Page
+  logoutAction: {}
 }
 
 export const state = (): QiitaState => ({
@@ -142,6 +144,14 @@ export const actions: DefineActions<
       commit('setIsLoading', { isLoading: false })
       commit('savePaging', { paging: response.paging })
       commit('saveCurrentPage', { currentPage: page.page })
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  },
+  logoutAction: async ({ commit }): Promise<void> => {
+    try {
+      await logout()
+      commit('saveSessionId', { sessionId: '' })
     } catch (error) {
       return Promise.reject(error)
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/33

# Doneの定義
ログアウトできること

# 変更点概要

## 仕様的変更点概要
ヘッダーの「ログアウト」押下により、ログアウト処理を追加。

## 技術的変更点概要
CookieからセッションIDを削除する必要があるため、サーバ上でAPIへのリクエストを行なっている。

また、このIssueとは直接関係ないが、ログイン後のリダイレクト処理を追加。
パラメータストアにフロントエンドのURLを追加する必要があるため、
https://github.com/nekochans/qiita-stocker-terraform/issues/109 にて対応する。