### PR TITLE
ページング機能を作成する

### DIFF
--- a/app/components/Pagination.vue
+++ b/app/components/Pagination.vue
@@ -1,0 +1,167 @@
+<template>
+  <div>
+    <ConfirmModal
+      :is-show="showConfirmation"
+      :message="confirmMessage"
+      @confirmModal="confirmPagination"
+      @cancelModal="cancelaPagination"
+    />
+    <nav
+      v-show="stocksLength && !isLoading"
+      class="pagination"
+      role="navigation"
+    >
+      <a
+        class="pagination-previous"
+        :disabled="!prevPage.page"
+        @click="goToPage(prevPage)"
+        >Previous</a
+      >
+      <a
+        class="pagination-next"
+        :disabled="!nextPage.page"
+        @click="goToPage(nextPage)"
+        >Next page</a
+      >
+      <ul class="pagination-list">
+        <li>
+          <a
+            v-show="showFirstEllipsis()"
+            class="pagination-link"
+            @click="goToPage(firstPage)"
+            >{{ firstPage.page }}</a
+          >
+        </li>
+        <li>
+          <span v-show="showPrevEllipsis()" class="pagination-ellipsis"
+            >&hellip;</span
+          >
+        </li>
+        <li>
+          <a
+            v-show="prevPage.page"
+            class="pagination-link"
+            @click="goToPage(prevPage)"
+            >{{ prevPage.page }}</a
+          >
+        </li>
+        <li>
+          <a class="pagination-link is-current">{{ currentPage }}</a>
+        </li>
+        <li>
+          <a
+            v-show="nextPage.page"
+            class="pagination-link"
+            @click="goToPage(nextPage)"
+            >{{ nextPage.page }}</a
+          >
+        </li>
+        <li>
+          <span v-show="showNestEllipsis()" class="pagination-ellipsis"
+            >&hellip;</span
+          >
+        </li>
+        <li>
+          <a
+            v-show="showLastPage()"
+            class="pagination-link"
+            @click="goToPage(lastPage)"
+            >{{ lastPage.page }}</a
+          >
+        </li>
+      </ul>
+    </nav>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+import { Page } from '@/domain/domain'
+
+@Component({
+  components: {
+    ConfirmModal
+  }
+})
+export default class extends Vue {
+  @Prop()
+  isLoading!: boolean
+
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  checkedStockArticleIds!: string[]
+
+  @Prop()
+  stocksLength!: number
+
+  @Prop()
+  currentPage!: number
+
+  @Prop()
+  firstPage!: { page: number; perPage: number; relation: string }
+
+  @Prop()
+  prevPage!: { page: number; perPage: number; relation: string }
+
+  @Prop()
+  nextPage!: { page: number; perPage: number; relation: string }
+
+  @Prop()
+  lastPage!: { page: number; perPage: number; relation: string }
+
+  targetPage!: Page
+  showConfirmation: boolean = false
+  confirmMessage: string =
+    '保存せずにページを遷移した場合、現在のストックの選択は解除されます。ページを移動してもよろしいですか？'
+
+  scrollIntoStockList() {
+    document.getElementById('pagination-scroll-top')!.scrollIntoView(true)
+  }
+
+  showFirstEllipsis() {
+    return this.firstPage.page !== this.prevPage.page
+  }
+
+  showPrevEllipsis() {
+    return this.firstPage.page + 1 < this.prevPage.page
+  }
+
+  showNestEllipsis() {
+    return this.nextPage.page + 1 < this.lastPage.page
+  }
+
+  showLastPage() {
+    return this.nextPage.page < this.lastPage.page
+  }
+
+  goToPage(page: Page) {
+    this.scrollIntoStockList()
+
+    this.targetPage = page
+
+    if (this.isCategorizing && this.checkedStockArticleIds.length)
+      return (this.showConfirmation = true)
+
+    return this.$emit('clickGoToPage', this.targetPage)
+  }
+
+  confirmPagination(): void {
+    this.showConfirmation = false
+    this.$emit('clickGoToPage', this.targetPage)
+  }
+
+  cancelaPagination(): void {
+    this.showConfirmation = false
+  }
+}
+</script>
+
+<style scoped>
+.pagination {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+</style>

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -69,16 +69,31 @@ import { Page } from '@/domain/domain'
     ])
   },
   methods: {
-    ...mapActions(['saveCategory', 'updateCategory', 'destroyCategory'])
+    ...mapActions([
+      'fetchUncategorizedStocks',
+      'saveCategory',
+      'updateCategory',
+      'destroyCategory'
+    ])
   }
 })
 export default class extends Vue {
+  fetchUncategorizedStocks!: (page?: Page) => void
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
 
-  fetchOtherPageStock(page: Page) {
-    console.log(`${page} fetchOtherPageStock`)
+  async fetchOtherPageStock(page: Page) {
+    try {
+      await this.fetchUncategorizedStocks(page)
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
   }
 
   async onClickSaveCategory(categoryName: string) {

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -19,6 +19,18 @@
             :is-categorizing="isCategorizing"
             :is-loading="isLoading"
           />
+          <Pagination
+            :is-loading="isLoading"
+            :is-categorizing="isCategorizing"
+            :checked-stock-article-ids="checkedStockArticleIds"
+            :stocks-length="uncategorizedStocks.length"
+            :current-page="currentPage"
+            :first-page="firstPage"
+            :prev-page="prevPage"
+            :next-page="nextPage"
+            :last-page="lastPage"
+            @clickGoToPage="fetchOtherPageStock"
+          />
         </div>
       </div>
     </main>
@@ -30,16 +42,25 @@ import { Component, Vue } from 'nuxt-property-decorator'
 import SideMenu from '@/components/SideMenu.vue'
 import StockList from '@/components/StockList.vue'
 import Loading from '@/components/Loading.vue'
+import Pagination from '@/components/Pagination.vue'
 import { mapGetters, mapActions, UpdateCategoryPayload } from '@/store/qiita'
+import { Page } from '@/domain/domain'
 
 @Component({
   components: {
     SideMenu,
     StockList,
-    Loading
+    Loading,
+    Pagination
   },
   computed: {
     ...mapGetters([
+      'currentPage',
+      'firstPage',
+      'prevPage',
+      'nextPage',
+      'lastPage',
+      'checkedStockArticleIds',
       'displayCategoryId',
       'categories',
       'uncategorizedStocks',
@@ -55,6 +76,10 @@ export default class extends Vue {
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
+
+  fetchOtherPageStock(page: Page) {
+    console.log(`${page} fetchOtherPageStock`)
+  }
 
   async onClickSaveCategory(categoryName: string) {
     try {

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -22,8 +22,8 @@ export default class extends Vue {
       await store.dispatch('qiita/fetchCategory')
     } catch (e) {
       error({
-        statusCode: e.response.data.code,
-        message: e.response.data.message
+        statusCode: e.code,
+        message: e.message
       })
     }
   }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -250,6 +250,8 @@ export const actions: DefineActions<
     page: Page = { page: state.currentPage, perPage: 20, relation: '' }
   ): Promise<void> => {
     try {
+      commit('setIsLoading', { isLoading: true })
+
       const fetchStockRequest: FetchUncategorizedStockRequest = {
         apiUrlBase: EnvConstant.apiUrlBase(),
         sessionId: state.sessionId,
@@ -277,6 +279,7 @@ export const actions: DefineActions<
       commit('savePaging', { paging: response.paging })
       commit('saveCurrentPage', { currentPage: page.page })
     } catch (error) {
+      commit('setIsLoading', { isLoading: false })
       return Promise.reject(error)
     }
   },

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -36,6 +36,12 @@ export type QiitaState = {
 
 export interface QiitaGetters {
   isLoggedIn: boolean
+  currentPage: number
+  firstPage: Page
+  prevPage: Page
+  nextPage: Page
+  lastPage: Page
+  checkedStockArticleIds: string[]
   displayCategoryId: number
   categories: Category[]
   uncategorizedStocks: UncategorizedStock[]
@@ -107,6 +113,54 @@ export type UpdateCategoryPayload = {
 export const getters: DefineGetters<QiitaGetters, QiitaState> = {
   isLoggedIn: (state): boolean => {
     return !!state.sessionId
+  },
+  currentPage: (state): number => {
+    return state.currentPage
+  },
+  firstPage: (state): Page => {
+    const page: Page | undefined = state.paging.find(page => {
+      return page.relation === 'first'
+    })
+
+    if (page !== undefined) {
+      return page
+    }
+    return { page: 0, perPage: 0, relation: '' }
+  },
+  prevPage: (state): Page => {
+    const page: Page | undefined = state.paging.find(page => {
+      return page.relation === 'prev'
+    })
+
+    if (page !== undefined) {
+      return page
+    }
+    return { page: 0, perPage: 0, relation: '' }
+  },
+  nextPage: (state): Page => {
+    const page: Page | undefined = state.paging.find(page => {
+      return page.relation === 'next'
+    })
+
+    if (page !== undefined) {
+      return page
+    }
+    return { page: 0, perPage: 0, relation: '' }
+  },
+  lastPage: (state): Page => {
+    const page: Page | undefined = state.paging.find(page => {
+      return page.relation === 'last'
+    })
+
+    if (page !== undefined) {
+      return page
+    }
+    return { page: 0, perPage: 0, relation: '' }
+  },
+  checkedStockArticleIds: (state): string[] => {
+    return state.uncategorizedStocks
+      .filter(stock => stock.isChecked)
+      .map(stock => stock.article_id)
   },
   displayCategoryId: (state): number => {
     return state.displayCategoryId


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/40

# Doneの定義
表題の通り

# 変更点概要

## 技術的変更点概要
ストック一覧にページングコンポーネンを表示。
ページングボタン押下時に、ストック取得APIへのリクエスト処理を追加。

Issueとは関係ないが、ページコンポーネントの`fetch`関数内のエラーハンドリングが不正で、エラー画面が表示されていなかったので修正。
(https://github.com/nekochans/qiita-stocker-nuxt/pull/63/files#diff-3d56125b9b9d7583c346338aac3565d9R62 の影響)