### PR TITLE
ストックのカテゴライズ機能を作成する

### DIFF
--- a/app/components/AlertModal.vue
+++ b/app/components/AlertModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <div :class="`modal ${isShow && 'is-active'}`">
+    <div class="modal-background" @click="onClickClose"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">
+          <span class="icon">
+            <i class="fas fa-exclamation-triangle"></i>
+          </span>
+        </p>
+      </header>
+      <section class="modal-card-body">{{ message }}</section>
+      <footer class="modal-card-foot">
+        <button class="button is-primary" @click="onClickClose">OK</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+
+@Component
+export default class AlertModal extends Vue {
+  @Prop()
+  isShow!: boolean
+
+  @Prop()
+  message!: string
+
+  onClickClose() {
+    this.$emit('closeModal')
+  }
+}
+</script>

--- a/app/components/CategorizeButton.vue
+++ b/app/components/CategorizeButton.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <AlertModal
+      :is-show="showAlert"
+      :message="alertMessage"
+      @closeModal="closeModal"
+    />
+    <div v-if="isCategorizing">
+      <div :class="`select edit-header ${isValidationError && 'is-danger'}`">
+        <select v-model="selectedCategory" @change="isValidationError = false">
+          <option
+            v-for="category in displayCategories"
+            :key="category.categoryId"
+            :value="category"
+            >{{ category.name }}</option
+          >
+        </select>
+      </div>
+      <button class="button is-danger button-margin" @click="changeCategory">
+        保存
+      </button>
+      <button
+        class="button is-white has-text-grey button-margin"
+        @click="cancel"
+      >
+        キャンセル
+      </button>
+    </div>
+    <div v-show="!isCancelingCategorization" v-else>
+      <button class="button is-light button-margin" @click="startEdit">
+        カテゴリに分類する
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import AlertModal from '@/components/AlertModal.vue'
+import { Category } from '@/domain/domain'
+
+@Component({
+  components: {
+    AlertModal
+  }
+})
+export default class extends Vue {
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  isCancelingCategorization!: boolean
+
+  @Prop()
+  displayCategories!: Category[]
+
+  @Prop()
+  checkedStockArticleIds!: string[]
+
+  selectedCategory: Category = { categoryId: 0, name: '' }
+  isValidationError: boolean = false
+  showAlert: boolean = false
+  alertMessage: string = 'ストックを1つ以上選択してください。'
+
+  doneEdit() {
+    this.isValidationError = false
+    this.$emit('clickSetIsCategorizing')
+  }
+
+  startEdit() {
+    this.doneEdit()
+  }
+
+  cancel() {
+    this.doneEdit()
+  }
+
+  changeCategory() {
+    if (!this.selectedCategory.categoryId)
+      return (this.isValidationError = true)
+
+    if (!this.checkedStockArticleIds.length) return (this.showAlert = true)
+
+    this.$emit('clickCategorize', this.selectedCategory)
+    return this.doneEdit()
+  }
+
+  closeModal() {
+    this.showAlert = false
+  }
+}
+</script>
+
+<style scoped>
+.edit-header {
+  margin-right: 10px;
+}
+
+.button-margin {
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/app/components/StockEdit.vue
+++ b/app/components/StockEdit.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    v-show="stocksLength && !isLoading"
+    :class="`${isCategorizing && 'stock-edit-sticky'}`"
+  >
+    <div class="navbar-menu edit-menu">
+      <div class="navbar-end">
+        <CategorizeButton
+          :is-categorizing="isCategorizing"
+          :is-canceling-categorization="isCancelingCategorization"
+          :display-categories="displayCategories"
+          :checked-stock-article-ids="checkedStockArticleIds"
+          @clickSetIsCategorizing="onSetIsCategorizing"
+          @clickCategorize="onClickCategorize"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import { Category } from '@/domain/domain'
+import CategorizeButton from '@/components/CategorizeButton.vue'
+
+@Component({
+  components: {
+    CategorizeButton
+  }
+})
+export default class extends Vue {
+  @Prop()
+  isLoading!: boolean
+
+  @Prop()
+  stocksLength!: number
+
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  isCancelingCategorization!: boolean
+
+  @Prop()
+  displayCategories!: Category
+
+  @Prop()
+  checkedStockArticleIds!: string[]
+
+  onSetIsCategorizing() {
+    this.$emit('clickSetIsCategorizing')
+  }
+
+  onClickCategorize(category: Category) {
+    this.$emit('clickCategorize', category)
+  }
+}
+</script>
+
+<style scoped>
+.edit-menu {
+  display: block;
+  box-shadow: none;
+}
+
+@media screen and (max-width: 768px) {
+  .stock-edit-sticky {
+    border-bottom: 1px solid #e8e8e8;
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+}
+</style>

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -87,7 +87,8 @@ import { Page, Category } from '@/domain/domain'
       'fetchUncategorizedStocks',
       'saveCategory',
       'updateCategory',
-      'destroyCategory'
+      'destroyCategory',
+      'setIsCategorizing'
     ])
   }
 })
@@ -96,6 +97,7 @@ export default class extends Vue {
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
+  setIsCategorizing!: () => void
 
   async fetchOtherPageStock(page: Page) {
     try {
@@ -150,7 +152,7 @@ export default class extends Vue {
   }
 
   onSetIsCategorizing() {
-    console.log('onSetIsCategorizing')
+    this.setIsCategorizing()
   }
 
   onClickCategorize(category: Category) {

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -13,6 +13,16 @@
         </div>
         <div class="column is-9">
           <Loading v-show="isLoading" />
+          <StockEdit
+            :is-loading="isLoading"
+            :stocks-length="uncategorizedStocks.length"
+            :is-categorizing="isCategorizing"
+            :is-canceling-categorization="isCancelingCategorization"
+            :display-categories="displayCategories"
+            :checked-stock-article-ids="checkedStockArticleIds"
+            @clickSetIsCategorizing="onSetIsCategorizing"
+            @clickCategorize="onClickCategorize"
+          />
           <StockList
             v-show="!isLoading"
             :stocks="uncategorizedStocks"
@@ -43,15 +53,17 @@ import SideMenu from '@/components/SideMenu.vue'
 import StockList from '@/components/StockList.vue'
 import Loading from '@/components/Loading.vue'
 import Pagination from '@/components/Pagination.vue'
+import StockEdit from '@/components/StockEdit.vue'
 import { mapGetters, mapActions, UpdateCategoryPayload } from '@/store/qiita'
-import { Page } from '@/domain/domain'
+import { Page, Category } from '@/domain/domain'
 
 @Component({
   components: {
     SideMenu,
     StockList,
     Loading,
-    Pagination
+    Pagination,
+    StockEdit
   },
   computed: {
     ...mapGetters([
@@ -62,9 +74,11 @@ import { Page } from '@/domain/domain'
       'lastPage',
       'checkedStockArticleIds',
       'displayCategoryId',
+      'displayCategories',
       'categories',
       'uncategorizedStocks',
       'isCategorizing',
+      'isCancelingCategorization',
       'isLoading'
     ])
   },
@@ -133,6 +147,19 @@ export default class extends Vue {
         }
       })
     }
+  }
+
+  onSetIsCategorizing() {
+    console.log('onSetIsCategorizing')
+  }
+
+  onClickCategorize(category: Category) {
+    console.log(`${category} onClickCategorize`)
+    //   const categorizePayload: ICategorizePayload = {
+    //     category: category,
+    //     stockArticleIds: this.checkedStockArticleIds
+    //   };
+    //   this.categorize(categorizePayload);
   }
 }
 </script>

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -28,6 +28,7 @@
             :stocks="uncategorizedStocks"
             :is-categorizing="isCategorizing"
             :is-loading="isLoading"
+            @clickCheckStock="onClickCheckStock"
           />
           <Pagination
             :is-loading="isLoading"
@@ -54,8 +55,13 @@ import StockList from '@/components/StockList.vue'
 import Loading from '@/components/Loading.vue'
 import Pagination from '@/components/Pagination.vue'
 import StockEdit from '@/components/StockEdit.vue'
-import { mapGetters, mapActions, UpdateCategoryPayload } from '@/store/qiita'
-import { Page, Category } from '@/domain/domain'
+import {
+  mapGetters,
+  mapActions,
+  UpdateCategoryPayload,
+  CategorizePayload
+} from '@/store/qiita'
+import { Page, Category, UncategorizedStock } from '@/domain/domain'
 
 @Component({
   components: {
@@ -88,7 +94,9 @@ import { Page, Category } from '@/domain/domain'
       'saveCategory',
       'updateCategory',
       'destroyCategory',
-      'setIsCategorizing'
+      'setIsCategorizing',
+      'categorize',
+      'checkStock'
     ])
   }
 })
@@ -98,6 +106,10 @@ export default class extends Vue {
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
   setIsCategorizing!: () => void
+  categorize!: (categorizePayload: CategorizePayload) => void
+  checkStock!: (stock: UncategorizedStock) => void
+
+  checkedStockArticleIds!: string[]
 
   async fetchOtherPageStock(page: Page) {
     try {
@@ -151,17 +163,29 @@ export default class extends Vue {
     }
   }
 
+  onClickCheckStock(stock: UncategorizedStock) {
+    this.checkStock(stock)
+  }
+
   onSetIsCategorizing() {
     this.setIsCategorizing()
   }
 
-  onClickCategorize(category: Category) {
-    console.log(`${category} onClickCategorize`)
-    //   const categorizePayload: ICategorizePayload = {
-    //     category: category,
-    //     stockArticleIds: this.checkedStockArticleIds
-    //   };
-    //   this.categorize(categorizePayload);
+  async onClickCategorize(category: Category) {
+    try {
+      const categorizePayload: CategorizePayload = {
+        category,
+        stockArticleIds: this.checkedStockArticleIds
+      }
+      await this.categorize(categorizePayload)
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
   }
 }
 </script>

--- a/app/domain/domain.ts
+++ b/app/domain/domain.ts
@@ -77,6 +77,13 @@ export type SaveCategoryRequest = {
 
 export type SaveCategoryResponse = Category & {}
 
+export type CategorizeRequest = {
+  apiUrlBase: string
+  sessionId: string
+  categoryId: number
+  articleIds: string[]
+}
+
 export type QiitaStockApi = {
   cancelAccount(): Promise<void>
   logout(): Promise<void>
@@ -91,6 +98,7 @@ export type QiitaStockApi = {
   ): Promise<FetchUncategorizedStockResponse>
   saveCategory(request: SaveCategoryRequest): Promise<SaveCategoryResponse>
   destroyCategory(request: DestroyCategoryRequest): Promise<void>
+  categorize(request: CategorizeRequest): Promise<void>
 }
 
 export const cancelAccount = async () => {
@@ -129,4 +137,8 @@ export const destroyCategory = (
   request: DestroyCategoryRequest
 ): Promise<void> => {
   return api.destroyCategory(request)
+}
+
+export const categorize = (request: CategorizeRequest): Promise<void> => {
+  return api.categorize(request)
 }

--- a/app/repositories/api.ts
+++ b/app/repositories/api.ts
@@ -11,7 +11,8 @@ import {
   FetchCategoriesResponse,
   UpdateCategoryRequest,
   UpdateCategoryResponse,
-  DestroyCategoryRequest
+  DestroyCategoryRequest,
+  CategorizeRequest
 } from '@/domain/domain'
 
 export default class Api implements QiitaStockApi {
@@ -158,6 +159,33 @@ export default class Api implements QiitaStockApi {
           'Content-Type': 'application/json'
         }
       })
+      .then(() => {
+        return Promise.resolve()
+      })
+      .catch((axiosError: QiitaStockerError) => {
+        return Promise.reject(axiosError.response.data)
+      })
+  }
+
+  /**
+   * @param request
+   * @return {Promise<void | never>}
+   */
+  categorize(request: CategorizeRequest): Promise<void> {
+    return axios
+      .post(
+        `${request.apiUrlBase}/api/categories/stocks`,
+        {
+          id: request.categoryId,
+          articleIds: request.articleIds
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      )
       .then(() => {
         return Promise.resolve()
       })

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -79,6 +79,7 @@ export interface QiitaMutations {
   }
   updateStockCategoryName: Category
   removeCategoryFromStock: number
+  setIsCategorizing: {}
 }
 
 export interface QiitaActions {
@@ -92,15 +93,13 @@ export interface QiitaActions {
   updateCategory: UpdateCategoryPayload
   saveCategory: string
   destroyCategory: number
+  setIsCategorizing: {}
 }
 
 export const state = (): QiitaState => ({
   sessionId: '',
   displayCategoryId: 0,
-  categories: [
-    { categoryId: 10, name: 'category name 1' },
-    { categoryId: 20, name: 'category name 2' }
-  ],
+  categories: [],
   uncategorizedStocks: [],
   isCategorizing: false,
   isCancelingCategorization: false,
@@ -237,6 +236,9 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
         stock.category = undefined
       }
     })
+  },
+  setIsCategorizing: state => {
+    state.isCategorizing = !state.isCategorizing
   }
 }
 
@@ -392,6 +394,9 @@ export const actions: DefineActions<
     } catch (error) {
       return Promise.reject(error)
     }
+  },
+  setIsCategorizing: ({ commit }) => {
+    commit('setIsCategorizing', {})
   }
 }
 

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -29,6 +29,7 @@ export type QiitaState = {
   categories: Category[]
   uncategorizedStocks: UncategorizedStock[]
   isCategorizing: boolean
+  isCancelingCategorization: boolean
   isLoading: boolean
   currentPage: number
   paging: Page[]
@@ -44,8 +45,10 @@ export interface QiitaGetters {
   checkedStockArticleIds: string[]
   displayCategoryId: number
   categories: Category[]
+  displayCategories: Category[]
   uncategorizedStocks: UncategorizedStock[]
   isCategorizing: boolean
+  isCancelingCategorization: boolean
   isLoading: boolean
 }
 
@@ -100,6 +103,7 @@ export const state = (): QiitaState => ({
   ],
   uncategorizedStocks: [],
   isCategorizing: false,
+  isCancelingCategorization: false,
   isLoading: true,
   currentPage: 1,
   paging: []
@@ -168,11 +172,19 @@ export const getters: DefineGetters<QiitaGetters, QiitaState> = {
   categories: (state): Category[] => {
     return state.categories
   },
+  displayCategories: (state): Category[] => {
+    return state.categories.filter(
+      category => category.categoryId !== state.displayCategoryId
+    )
+  },
   uncategorizedStocks: (state): UncategorizedStock[] => {
     return state.uncategorizedStocks
   },
   isCategorizing: (state): boolean => {
     return state.isCategorizing
+  },
+  isCancelingCategorization: (state): boolean => {
+    return state.isCancelingCategorization
   },
   isLoading: (state): boolean => {
     return state.isLoading


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/36

# Doneの定義
表題の通り

# 変更点概要

## 技術的変更点概要
ストック一覧上部に`カテゴリに分類する`ボタンを追加。
カテゴライズAPIへのリクエスト処理を追加し、ストックのカテゴライズ機能を作成。