### PR TITLE
カテゴライズされたストックを表示する機能を作成する

### DIFF
--- a/app/components/CategorizedStock.vue
+++ b/app/components/CategorizedStock.vue
@@ -1,0 +1,115 @@
+<template>
+  <article class="media">
+    <figure class="media-left">
+      <a class="image is-48x48" :href="`https://qiita.com/${stock.user_id}`">
+        <img :src="stock.profile_image_url" />
+      </a>
+    </figure>
+    <div class="media-content content-no-scroll">
+      <div class="content">
+        <div class="item-info">
+          <p>
+            <a :href="`https://qiita.com/${stock.user_id}`">{{
+              stock.user_id
+            }}</a
+            >が{{ stock.article_created_at }}に投稿しました
+          </p>
+        </div>
+        <div class="item-title">
+          <a
+            :href="
+              `https://qiita.com/${stock.user_id}/items/${stock.article_id}`
+            "
+            >{{ stock.title }}</a
+          >
+        </div>
+        <div class="tags">
+          <span v-for="(tag, key) in stock.tags" :key="key" class="tag">
+            {{ tag }}
+          </span>
+        </div>
+      </div>
+    </div>
+    <label v-show="isCategorizing" class="checkbox checkbox-size">
+      <input
+        type="checkbox"
+        :checked="stock.isChecked"
+        class="checkbox-margin"
+        @change="onClickCheckStock"
+      />
+    </label>
+    <p
+      v-show="!isCategorizing && isCancelingCategorization"
+      class="times-circle"
+      @click="onClickCancelCategorization"
+    >
+      <span class="icon"> <i class="far fa-times-circle fa-2x"></i> </span>
+    </p>
+  </article>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import { CategorizedStock } from '@/domain/domain'
+
+@Component
+export default class extends Vue {
+  @Prop()
+  stock!: CategorizedStock
+
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  isCancelingCategorization!: boolean
+
+  onClickCheckStock() {
+    this.$emit('clickCheckStock', this.stock)
+  }
+
+  onClickCancelCategorization() {
+    this.$emit('clickCancelCategorization', this.stock.id)
+  }
+}
+</script>
+
+<style scoped>
+.checkbox-size {
+  zoom: 3;
+}
+
+a {
+  color: #337ab7;
+}
+
+a:hover {
+  color: #23527c;
+}
+
+.media {
+  font-size: 12px;
+}
+
+.item-info {
+  font-size: 1em;
+}
+.item-title {
+  margin-bottom: 0.3em;
+  font-size: 1.4em;
+}
+
+.content-no-scroll {
+  overflow-x: visible;
+}
+
+.times-circle {
+  color: darkgray;
+  float: right;
+  transition: color 0.2s ease-out;
+  padding: 0.5rem;
+}
+
+.times-circle:hover {
+  color: gray;
+}
+</style>

--- a/app/components/CategorizedStockEdit.vue
+++ b/app/components/CategorizedStockEdit.vue
@@ -1,0 +1,94 @@
+<template>
+  <div
+    v-show="stocksLength && !isLoading"
+    :class="`${isSticky && 'stock-edit-sticky'}`"
+  >
+    <div class="navbar-menu edit-menu">
+      <div class="navbar-end">
+        <div v-if="!isCategorizing" class="cancel-categorization-margin">
+          <button
+            :class="
+              `button is-light button-margin ${isCancelingCategorization &&
+                'is-link'}`
+            "
+            @click="setIsCancelingCategorization"
+          >
+            カテゴライズを解除する
+          </button>
+        </div>
+        <CategorizeButton
+          :is-categorizing="isCategorizing"
+          :is-canceling-categorization="isCancelingCategorization"
+          :display-categories="displayCategories"
+          :checked-stock-article-ids="checkedStockArticleIds"
+          @clickSetIsCategorizing="onSetIsCategorizing"
+          @clickCategorize="onClickCategorize"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import { Category } from '@/domain/domain'
+import CategorizeButton from '@/components/CategorizeButton.vue'
+
+@Component({
+  components: {
+    CategorizeButton
+  }
+})
+export default class extends Vue {
+  @Prop()
+  isLoading!: boolean
+
+  @Prop()
+  stocksLength!: number
+
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  isCancelingCategorization!: boolean
+
+  @Prop()
+  displayCategories!: Category
+
+  @Prop()
+  checkedStockArticleIds!: string[]
+
+  get isSticky(): boolean {
+    return this.isCategorizing || this.isCancelingCategorization
+  }
+
+  setIsCancelingCategorization() {
+    this.$emit('clickSetIsCancelingCategorization')
+  }
+
+  onSetIsCategorizing() {
+    this.$emit('clickSetIsCategorizing')
+  }
+
+  onClickCategorize(category: Category) {
+    this.$emit('clickCategorize', category)
+  }
+}
+</script>
+
+<style scoped>
+.edit-menu {
+  display: block;
+  box-shadow: none;
+}
+
+@media screen and (max-width: 768px) {
+  .stock-edit-sticky {
+    border-bottom: 1px solid #e8e8e8;
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+}
+</style>

--- a/app/components/CategorizedStockEdit.vue
+++ b/app/components/CategorizedStockEdit.vue
@@ -82,6 +82,14 @@ export default class extends Vue {
   box-shadow: none;
 }
 
+.cancel-categorization-margin {
+  margin-right: 0.5rem;
+}
+
+.button-margin {
+  margin-bottom: 0.5rem;
+}
+
 @media screen and (max-width: 768px) {
   .stock-edit-sticky {
     border-bottom: 1px solid #e8e8e8;

--- a/app/components/CategorizedStockList.vue
+++ b/app/components/CategorizedStockList.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <div v-if="stocks.length">
+      <CategorizedStockItem
+        v-for="stock in stocks"
+        :key="stock.article_id"
+        :stock="stock"
+        :is-categorizing="isCategorizing"
+        :is-canceling-categorization="isCancelingCategorization"
+        @clickCheckStock="onClickCheckStock"
+        @clickCancelCategorization="onClickCancelCategorization"
+      />
+    </div>
+    <div v-else><h1 class="subtitle">ストックされた記事はありません。</h1></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import CategorizedStockItem from '@/components/CategorizedStock.vue'
+import { CategorizedStock } from '@/domain/domain'
+
+@Component({
+  components: {
+    CategorizedStockItem
+  }
+})
+export default class StockList extends Vue {
+  @Prop()
+  stocks!: CategorizedStock[]
+
+  @Prop()
+  isCategorizing!: boolean
+
+  @Prop()
+  isCancelingCategorization!: boolean
+
+  onClickCheckStock(stock: any) {
+    this.$emit('clickCheckStock', stock)
+  }
+
+  onClickCancelCategorization(categorizedStockId: number) {
+    this.$emit('clickCancelCategorization', categorizedStockId)
+  }
+}
+</script>

--- a/app/components/Category.vue
+++ b/app/components/Category.vue
@@ -90,7 +90,11 @@ export default class extends Vue {
   cancelButtonText: string = 'キャンセル'
 
   onClickCategory() {
-    // TODO カテゴリ選択時の処理を追加
+    if (this.editing || this.isSelecting) return
+
+    const categoryId: string = String(this.category.categoryId)
+    this.$emit('clickCategory')
+    this.$router.push({ path: `/stocks/categories/${categoryId}` })
   }
 
   doneEdit() {
@@ -131,12 +135,9 @@ export default class extends Vue {
     this.showConfirmation = false
     this.$emit('clickDestroyCategory', this.category.categoryId)
 
-    // TODO 選択中のカテゴリが削除された場合は全てのストックを表示する
-    // if (this.isSelecting) {
-    //   this.$router.push({
-    //     name: 'stocks'
-    //   })
-    // }
+    if (this.isSelecting) {
+      this.$router.push({ path: `/stocks/all` })
+    }
   }
 
   cancelDestroy(): void {
@@ -145,6 +146,15 @@ export default class extends Vue {
 
   buildConfirmMessage(categoryName: string): string {
     return `${categoryName} を削除してもよろしいですか？`
+  }
+
+  initializeIsSelecting() {
+    const query: any = this.$route.params
+    this.isSelecting = String(this.category.categoryId) === query.id
+  }
+
+  created() {
+    this.initializeIsSelecting()
   }
 }
 </script>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -7,8 +7,8 @@
         :key="category.categoryId"
         :category="category"
         @clickUpdateCategory="onClickUpdateCategory"
-        @clickCategory="onClickCategory"
         @clickDestroyCategory="onClickDestroyCategory"
+        @clickCategory="onClickCategory"
       />
     </ul>
   </section>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -30,7 +30,7 @@ export default class extends Vue {
   categories!: Category[]
 
   onClickCategory() {
-    // TODO カテゴリ選択時の処理を追加
+    this.$emit('clickCategory')
   }
 
   onClickUpdateCategory(updateCategoryPayload: UpdateCategoryPayload) {

--- a/app/components/SideMenu.vue
+++ b/app/components/SideMenu.vue
@@ -32,6 +32,10 @@ export default class extends Vue {
   @Prop()
   categories!: Category[]
 
+  onClickCategory() {
+    this.$emit('clickCategory')
+  }
+
   onClickSaveCategory(category: string) {
     this.$emit('clickSaveCategory', category)
   }

--- a/app/components/SideMenu.vue
+++ b/app/components/SideMenu.vue
@@ -5,6 +5,7 @@
       :categories="categories"
       @clickUpdateCategory="onClickUpdateCategory"
       @clickDestroyCategory="onClickDestroyCategory"
+      @clickCategory="onClickCategory"
     />
     <CreateCategory @clickSaveCategory="onClickSaveCategory" />
   </aside>

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -113,8 +113,7 @@ export default class extends Vue {
   checkedStockArticleIds!: string[]
 
   onClickCategory() {
-    // TODO カテゴリー選択時の動作を追加
-    // this.resetData();
+    // 全てのストックが選択されている場合は何もしない
   }
 
   async fetchOtherPageStock(page: Page) {

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -93,6 +93,7 @@ import { Page, Category, UncategorizedStock } from '@/domain/domain'
   methods: {
     ...mapActions([
       'fetchUncategorizedStocks',
+      'fetchCategory',
       'saveCategory',
       'updateCategory',
       'destroyCategory',
@@ -104,13 +105,16 @@ import { Page, Category, UncategorizedStock } from '@/domain/domain'
 })
 export default class extends Vue {
   fetchUncategorizedStocks!: (page?: Page) => void
+  fetchCategory!: () => void
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
   setIsCategorizing!: () => void
   categorize!: (categorizePayload: CategorizePayload) => void
   checkStock!: (stock: UncategorizedStock) => void
+
   checkedStockArticleIds!: string[]
+  categories!: Category[]
 
   onClickCategory() {
     // 全てのストックが選択されている場合は何もしない
@@ -196,6 +200,25 @@ export default class extends Vue {
   onClickStocksAll() {
     // TODO 全てのストック選択時の動作を追加
     // this.resetData()
+  }
+
+  async initializeCategory() {
+    try {
+      await this.fetchCategory()
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
+  }
+
+  async created() {
+    if (!this.categories.length) {
+      await this.initializeCategory()
+    }
   }
 }
 </script>

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -95,6 +95,7 @@ import { Page, Category, CategorizedStock } from '@/domain/domain'
   methods: {
     ...mapActions([
       'fetchCategorizedStock',
+      'fetchCategory',
       'saveCategory',
       'updateCategory',
       'destroyCategory',
@@ -110,6 +111,7 @@ export default class extends Vue {
   fetchCategorizedStock!: (
     fetchCategorizedStockPayload: FetchCategorizedStockPayload
   ) => void
+  fetchCategory!: () => void
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
@@ -117,8 +119,10 @@ export default class extends Vue {
   setIsCancelingCategorization!: () => void
   categorize!: (categorizePayload: CategorizePayload) => void
   checkStock!: (stock: CategorizedStock) => void
-  checkedCategorizedStockArticleIds!: string[]
   resetData!: () => void
+
+  checkedCategorizedStockArticleIds!: string[]
+  categories!: Category[]
 
   onClickCategory() {
     this.resetData()
@@ -215,6 +219,25 @@ export default class extends Vue {
   onClickStocksAll() {
     // TODO 全てのストック選択時の動作を追加
     // this.resetData()
+  }
+
+  async initializeCategory() {
+    try {
+      await this.fetchCategory()
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
+  }
+
+  async created() {
+    if (!this.categories.length) {
+      await this.initializeCategory()
+    }
   }
 }
 </script>

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -101,7 +101,8 @@ import { Page, Category, CategorizedStock } from '@/domain/domain'
       'setIsCategorizing',
       'setIsCancelingCategorization',
       'categorize',
-      'checkStock'
+      'checkStock',
+      'resetData'
     ])
   }
 })
@@ -117,10 +118,10 @@ export default class extends Vue {
   categorize!: (categorizePayload: CategorizePayload) => void
   checkStock!: (stock: CategorizedStock) => void
   checkedCategorizedStockArticleIds!: string[]
+  resetData!: () => void
 
   onClickCategory() {
-    // TODO カテゴリー選択時の動作を追加
-    // this.resetData();
+    this.resetData()
   }
 
   async onClickSaveCategory(categoryName: string) {

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -15,28 +15,29 @@
         </div>
         <div class="column is-9">
           <Loading v-show="isLoading" />
-          <StockEdit
+          <CategorizedStockEdit
             :is-loading="isLoading"
-            :stocks-length="uncategorizedStocks.length"
+            :stocks-length="categorizedStocks.length"
             :is-categorizing="isCategorizing"
             :is-canceling-categorization="isCancelingCategorization"
             :display-categories="displayCategories"
-            :checked-stock-article-ids="checkedStockArticleIds"
+            :checked-stock-article-ids="checkedCategorizedStockArticleIds"
             @clickSetIsCategorizing="onSetIsCategorizing"
+            @clickSetIsCancelingCategorization="onSetIsCancelingCategorization"
             @clickCategorize="onClickCategorize"
           />
-          <StockList
+          <CategorizedStockList
             v-show="!isLoading"
-            :stocks="uncategorizedStocks"
+            :stocks="categorizedStocks"
             :is-categorizing="isCategorizing"
-            :is-loading="isLoading"
             @clickCheckStock="onClickCheckStock"
+            @clickCancelCategorization="onClickCancelCategorization"
           />
           <Pagination
             :is-loading="isLoading"
             :is-categorizing="isCategorizing"
-            :checked-stock-article-ids="checkedStockArticleIds"
-            :stocks-length="uncategorizedStocks.length"
+            :checked-stock-article-ids="checkedCategorizedStockArticleIds"
+            :stocks-length="categorizedStocks.length"
             :current-page="currentPage"
             :first-page="firstPage"
             :prev-page="prevPage"
@@ -53,25 +54,26 @@
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
 import SideMenu from '@/components/SideMenu.vue'
-import StockList from '@/components/StockList.vue'
+import CategorizedStockList from '@/components/CategorizedStockList.vue'
 import Loading from '@/components/Loading.vue'
 import Pagination from '@/components/Pagination.vue'
-import StockEdit from '@/components/StockEdit.vue'
+import CategorizedStockEdit from '@/components/CategorizedStockEdit.vue'
 import {
   mapGetters,
   mapActions,
   UpdateCategoryPayload,
-  CategorizePayload
+  CategorizePayload,
+  FetchCategorizedStockPayload
 } from '@/store/qiita'
-import { Page, Category, UncategorizedStock } from '@/domain/domain'
+import { Page, Category, CategorizedStock } from '@/domain/domain'
 
 @Component({
   components: {
     SideMenu,
-    StockList,
+    CategorizedStockList,
     Loading,
     Pagination,
-    StockEdit
+    CategorizedStockEdit
   },
   computed: {
     ...mapGetters([
@@ -80,11 +82,11 @@ import { Page, Category, UncategorizedStock } from '@/domain/domain'
       'prevPage',
       'nextPage',
       'lastPage',
-      'checkedStockArticleIds',
+      'checkedCategorizedStockArticleIds',
       'displayCategoryId',
       'displayCategories',
       'categories',
-      'uncategorizedStocks',
+      'categorizedStocks',
       'isCategorizing',
       'isCancelingCategorization',
       'isLoading'
@@ -92,42 +94,33 @@ import { Page, Category, UncategorizedStock } from '@/domain/domain'
   },
   methods: {
     ...mapActions([
-      'fetchUncategorizedStocks',
+      'fetchCategorizedStock',
       'saveCategory',
       'updateCategory',
       'destroyCategory',
       'setIsCategorizing',
+      'setIsCancelingCategorization',
       'categorize',
       'checkStock'
     ])
   }
 })
 export default class extends Vue {
-  fetchUncategorizedStocks!: (page?: Page) => void
+  fetchCategorizedStock!: (
+    fetchCategorizedStockPayload: FetchCategorizedStockPayload
+  ) => void
   saveCategory!: (category: string) => void
   updateCategory!: (updateCategoryPayload: UpdateCategoryPayload) => void
   destroyCategory!: (categoryId: number) => void
   setIsCategorizing!: () => void
+  setIsCancelingCategorization!: () => void
   categorize!: (categorizePayload: CategorizePayload) => void
-  checkStock!: (stock: UncategorizedStock) => void
-  checkedStockArticleIds!: string[]
+  checkStock!: (stock: CategorizedStock) => void
+  checkedCategorizedStockArticleIds!: string[]
 
   onClickCategory() {
     // TODO カテゴリー選択時の動作を追加
     // this.resetData();
-  }
-
-  async fetchOtherPageStock(page: Page) {
-    try {
-      await this.fetchUncategorizedStocks(page)
-    } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
-      })
-    }
   }
 
   async onClickSaveCategory(categoryName: string) {
@@ -169,19 +162,11 @@ export default class extends Vue {
     }
   }
 
-  onClickCheckStock(stock: UncategorizedStock) {
-    this.checkStock(stock)
-  }
-
-  onSetIsCategorizing() {
-    this.setIsCategorizing()
-  }
-
   async onClickCategorize(category: Category) {
     try {
       const categorizePayload: CategorizePayload = {
         category,
-        stockArticleIds: this.checkedStockArticleIds
+        stockArticleIds: this.checkedCategorizedStockArticleIds
       }
       await this.categorize(categorizePayload)
     } catch (error) {
@@ -192,6 +177,38 @@ export default class extends Vue {
         }
       })
     }
+  }
+
+  onClickCancelCategorization(categorizedStockId: number) {
+    // TODO カテゴライズ解除ボタン押下時の動作を追加
+    console.log(`${categorizedStockId} onClickCancelCategorization`)
+    // this.cancelCategorization(categorizedStockId);
+  }
+
+  onClickCheckStock(stock: CategorizedStock) {
+    this.checkStock(stock)
+  }
+
+  fetchOtherPageStock(page: Page) {
+    console.log(`${page} fetchOtherPageStock`)
+    // try {
+    //   await this.fetchUncategorizedStocks(page)
+    // } catch (error) {
+    //   this.$router.push({
+    //     name: 'original_error',
+    //     params: {
+    //       message: error.message
+    //     }
+    //   })
+    // }
+  }
+
+  onSetIsCategorizing() {
+    this.setIsCategorizing()
+  }
+
+  onSetIsCancelingCategorization() {
+    this.setIsCancelingCategorization()
   }
 
   onClickStocksAll() {

--- a/app/domain/domain.ts
+++ b/app/domain/domain.ts
@@ -32,6 +32,15 @@ export type Stock = {
   tags: string[]
 }
 
+export type FetchedCategorizedStock = Stock & {
+  id: number
+}
+
+export type CategorizedStock = Stock & {
+  id: number
+  isChecked: boolean
+}
+
 export type UncategorizedStock = Stock & {
   category?: Category
   isChecked: boolean
@@ -69,6 +78,19 @@ export type FetchUncategorizedStockResponse = {
   stocks: { stock: Stock; category?: Category }[]
 }
 
+export type FetchCategorizedStockRequest = {
+  apiUrlBase: string
+  sessionId: string
+  categoryId: number
+  page: number
+  parPage: number
+}
+
+export type FetchCategorizedStockResponse = {
+  paging: Page[]
+  stocks: FetchedCategorizedStock[]
+}
+
 export type SaveCategoryRequest = {
   apiUrlBase: string
   name: string
@@ -96,6 +118,9 @@ export type QiitaStockApi = {
   fetchUncategorizedStocks(
     request: FetchUncategorizedStockRequest
   ): Promise<FetchUncategorizedStockResponse>
+  fetchCategorizedStocks(
+    request: FetchCategorizedStockRequest
+  ): Promise<FetchCategorizedStockResponse>
   saveCategory(request: SaveCategoryRequest): Promise<SaveCategoryResponse>
   destroyCategory(request: DestroyCategoryRequest): Promise<void>
   categorize(request: CategorizeRequest): Promise<void>
@@ -125,6 +150,12 @@ export const fetchUncategorizedStocks = (
   request: FetchUncategorizedStockRequest
 ): Promise<FetchUncategorizedStockResponse> => {
   return api.fetchUncategorizedStocks(request)
+}
+
+export const fetchCategorizedStocks = (
+  request: FetchCategorizedStockRequest
+): Promise<FetchCategorizedStockResponse> => {
+  return api.fetchCategorizedStocks(request)
 }
 
 export const saveCategory = (

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -19,7 +19,6 @@ export default class extends Vue {
   async fetch({ store, error }: NuxtContext) {
     try {
       await store.dispatch('qiita/fetchUncategorizedStocks')
-      await store.dispatch('qiita/fetchCategory')
     } catch (e) {
       error({
         statusCode: e.code,

--- a/app/pages/stocks/categories/_id.vue
+++ b/app/pages/stocks/categories/_id.vue
@@ -1,0 +1,42 @@
+<template>
+  <section>
+    <StockCategories />
+  </section>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import StockCategories from '@/components/pages/stocks/categories/stockCategories.vue'
+import { NuxtContext } from '@/types'
+import { FetchCategorizedStockPayload } from '@/store/qiita'
+
+@Component({
+  layout: 'stocks',
+  components: {
+    StockCategories
+  }
+})
+export default class extends Vue {
+  async fetch({ store, error }: NuxtContext) {
+    try {
+      // TODO カテゴリーIDを変更
+      const categoryId = 6
+      const fetchCategorizedStockPayload: FetchCategorizedStockPayload = {
+        categoryId,
+        page: { page: 0, perPage: 0, relation: '' }
+      }
+
+      await store.dispatch(
+        'qiita/fetchCategorizedStock',
+        fetchCategorizedStockPayload
+      )
+      await store.dispatch('qiita/fetchCategory')
+    } catch (e) {
+      error({
+        statusCode: e.code,
+        message: e.message
+      })
+    }
+  }
+}
+</script>

--- a/app/pages/stocks/categories/_id.vue
+++ b/app/pages/stocks/categories/_id.vue
@@ -30,6 +30,7 @@ export default class extends Vue {
         'qiita/fetchCategorizedStock',
         fetchCategorizedStockPayload
       )
+      await store.dispatch('qiita/saveDisplayCategoryId', categoryId)
     } catch (e) {
       error({
         statusCode: e.code,

--- a/app/pages/stocks/categories/_id.vue
+++ b/app/pages/stocks/categories/_id.vue
@@ -17,10 +17,10 @@ import { FetchCategorizedStockPayload } from '@/store/qiita'
   }
 })
 export default class extends Vue {
-  async fetch({ store, error }: NuxtContext) {
+  async fetch({ store, error, route }: NuxtContext) {
     try {
-      // TODO カテゴリーIDを変更
-      const categoryId = 6
+      const id = route.params.id
+      const categoryId: number = parseInt(id)
       const fetchCategorizedStockPayload: FetchCategorizedStockPayload = {
         categoryId,
         page: { page: 0, perPage: 0, relation: '' }
@@ -30,7 +30,6 @@ export default class extends Vue {
         'qiita/fetchCategorizedStock',
         fetchCategorizedStockPayload
       )
-      await store.dispatch('qiita/fetchCategory')
     } catch (e) {
       error({
         statusCode: e.code,

--- a/app/repositories/api.ts
+++ b/app/repositories/api.ts
@@ -5,6 +5,8 @@ import {
   Page,
   FetchUncategorizedStockRequest,
   FetchUncategorizedStockResponse,
+  FetchCategorizedStockRequest,
+  FetchCategorizedStockResponse,
   SaveCategoryRequest,
   SaveCategoryResponse,
   FetchCategoriesRequest,
@@ -112,6 +114,34 @@ export default class Api implements QiitaStockApi {
         const paging: Page[] = this.parseLinkHeader(linkHeader)
 
         const response: FetchUncategorizedStockResponse = {
+          stocks: axiosResponse.data,
+          paging
+        }
+
+        return Promise.resolve(response)
+      })
+      .catch((axiosError: QiitaStockerError) => {
+        return Promise.reject(axiosError.response.data)
+      })
+  }
+
+  fetchCategorizedStocks(
+    request: FetchCategorizedStockRequest
+  ): Promise<FetchCategorizedStockResponse> {
+    return axios
+      .get<FetchCategorizedStockResponse>(
+        `${request.apiUrlBase}/api/stocks/categories/${request.categoryId}?page=${request.page}&per_page=${request.parPage}`,
+        {
+          headers: {
+            Authorization: `Bearer ${request.sessionId}`
+          }
+        }
+      )
+      .then((axiosResponse: AxiosResponse) => {
+        const linkHeader: string = axiosResponse.headers.link
+        const paging: Page[] = this.parseLinkHeader(linkHeader)
+
+        const response: FetchCategorizedStockResponse = {
           stocks: axiosResponse.data,
           paging
         }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -80,6 +80,9 @@ export interface QiitaMutations {
   saveCurrentPage: {
     currentPage: number
   }
+  saveDisplayCategoryId: {
+    categoryId: number
+  }
   savePaging: {
     paging: Page[]
   }
@@ -124,6 +127,7 @@ export interface QiitaActions {
   setIsCancelingCategorization: {}
   categorize: CategorizePayload
   checkStock: UncategorizedStock
+  saveDisplayCategoryId: number
   resetData: {}
 }
 
@@ -260,6 +264,9 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
   },
   saveCurrentPage: (state, { currentPage }) => {
     state.currentPage = currentPage
+  },
+  saveDisplayCategoryId: (state, { categoryId }) => {
+    state.displayCategoryId = categoryId
   },
   savePaging: (state, { paging }) => {
     state.paging = paging
@@ -556,6 +563,9 @@ export const actions: DefineActions<
   },
   checkStock: ({ commit }, stock: UncategorizedStock): void => {
     commit('checkStock', { stock, isChecked: !stock.isChecked })
+  },
+  saveDisplayCategoryId: ({ commit }, categoryId: number): void => {
+    commit('saveDisplayCategoryId', { categoryId })
   },
   resetData: ({ commit }): void => {
     commit('resetData', {})

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -523,9 +523,7 @@ export const actions: DefineActions<
       commit('removeCategory', categoryId)
       commit('removeCategoryFromStock', categoryId)
 
-      // TODO 選択中のカテゴリが削除された場合の処理を追加
-      // if (state.displayCategoryId === categoryId)
-      //   return commit("saveDisplayCategoryId", 0);
+      if (state.displayCategoryId === categoryId) return commit('resetData', {})
     } catch (error) {
       return Promise.reject(error)
     }

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -102,6 +102,7 @@ export interface QiitaMutations {
     stockArticleIds: string[]
     category: Category
   }
+  resetData: {}
 }
 
 export interface QiitaActions {
@@ -120,6 +121,7 @@ export interface QiitaActions {
   setIsCancelingCategorization: {}
   categorize: CategorizePayload
   checkStock: UncategorizedStock
+  resetData: {}
 }
 
 export const state = (): QiitaState => ({
@@ -305,6 +307,12 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
         stock.category = category
       }
     })
+  },
+  resetData: state => {
+    state.isCategorizing = false
+    state.isCancelingCategorization = false
+    state.displayCategoryId = 0
+    state.currentPage = 1
   }
 }
 
@@ -539,6 +547,11 @@ export const actions: DefineActions<
   },
   checkStock: ({ commit }, stock: UncategorizedStock): void => {
     commit('checkStock', { stock, isChecked: !stock.isChecked })
+  },
+  resetData: ({ commit }): void => {
+    commit('resetData', {})
+    commit('saveUncategorizedStocks', { uncategorizedStocks: [] })
+    commit('saveCategorizedStocks', { categorizedStocks: [] })
   }
 }
 

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -34,7 +34,7 @@ export type QiitaState = {
   displayCategoryId: number
   categories: Category[]
   uncategorizedStocks: UncategorizedStock[]
-  categorizedStock: CategorizedStock[]
+  categorizedStocks: CategorizedStock[]
   isCategorizing: boolean
   isCancelingCategorization: boolean
   isLoading: boolean
@@ -50,10 +50,12 @@ export interface QiitaGetters {
   nextPage: Page
   lastPage: Page
   checkedStockArticleIds: string[]
+  checkedCategorizedStockArticleIds: string[]
   displayCategoryId: number
   categories: Category[]
   displayCategories: Category[]
   uncategorizedStocks: UncategorizedStock[]
+  categorizedStocks: CategorizedStock[]
   isCategorizing: boolean
   isCancelingCategorization: boolean
   isLoading: boolean
@@ -90,6 +92,7 @@ export interface QiitaMutations {
   updateStockCategoryName: Category
   removeCategoryFromStock: number
   setIsCategorizing: {}
+  setIsCancelingCategorization: {}
   checkStock: {
     stock: UncategorizedStock
     isChecked: boolean
@@ -114,6 +117,7 @@ export interface QiitaActions {
   saveCategory: string
   destroyCategory: number
   setIsCategorizing: {}
+  setIsCancelingCategorization: {}
   categorize: CategorizePayload
   checkStock: UncategorizedStock
 }
@@ -123,10 +127,10 @@ export const state = (): QiitaState => ({
   displayCategoryId: 0,
   categories: [],
   uncategorizedStocks: [],
-  categorizedStock: [],
+  categorizedStocks: [],
   isCategorizing: false,
   isCancelingCategorization: false,
-  isLoading: true,
+  isLoading: false,
   currentPage: 1,
   paging: []
 })
@@ -198,6 +202,11 @@ export const getters: DefineGetters<QiitaGetters, QiitaState> = {
       .filter(stock => stock.isChecked)
       .map(stock => stock.article_id)
   },
+  checkedCategorizedStockArticleIds: (state): string[] => {
+    return state.categorizedStocks
+      .filter(categorizedStock => categorizedStock.isChecked)
+      .map(categorizedStock => categorizedStock.article_id)
+  },
   displayCategoryId: (state): number => {
     return state.displayCategoryId
   },
@@ -211,6 +220,9 @@ export const getters: DefineGetters<QiitaGetters, QiitaState> = {
   },
   uncategorizedStocks: (state): UncategorizedStock[] => {
     return state.uncategorizedStocks
+  },
+  categorizedStocks: (state): CategorizedStock[] => {
+    return state.categorizedStocks
   },
   isCategorizing: (state): boolean => {
     return state.isCategorizing
@@ -231,7 +243,7 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
     state.uncategorizedStocks = uncategorizedStocks
   },
   saveCategorizedStocks: (state, { categorizedStocks }) => {
-    state.categorizedStock = categorizedStocks
+    state.categorizedStocks = categorizedStocks
   },
   setIsLoading: (state, { isLoading }) => {
     state.isLoading = isLoading
@@ -275,6 +287,9 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
   },
   setIsCategorizing: state => {
     state.isCategorizing = !state.isCategorizing
+  },
+  setIsCancelingCategorization: state => {
+    state.isCancelingCategorization = !state.isCancelingCategorization
   },
   checkStock: (_state, { stock, isChecked }) => {
     stock.isChecked = isChecked
@@ -391,7 +406,6 @@ export const actions: DefineActions<
       commit('setIsLoading', { isLoading: false })
     } catch (error) {
       commit('setIsLoading', { isLoading: false })
-
       return Promise.reject(error)
     }
   },
@@ -495,6 +509,9 @@ export const actions: DefineActions<
   },
   setIsCategorizing: ({ commit }) => {
     commit('setIsCategorizing', {})
+  },
+  setIsCancelingCategorization: ({ commit }) => {
+    commit('setIsCancelingCategorization', {})
   },
   categorize: async (
     { commit, state },

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -71,6 +71,9 @@ export interface QiitaMutations {
   saveCategorizedStocks: {
     categorizedStocks: CategorizedStock[]
   }
+  removeCategorizedStocks: {
+    stockArticleIds: string[]
+  }
   setIsLoading: {
     isLoading: boolean
   }
@@ -246,6 +249,11 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
   },
   saveCategorizedStocks: (state, { categorizedStocks }) => {
     state.categorizedStocks = categorizedStocks
+  },
+  removeCategorizedStocks: (state, { stockArticleIds }) => {
+    state.categorizedStocks = state.categorizedStocks.filter(
+      categorizedStock => !stockArticleIds.includes(categorizedStock.article_id)
+    )
   },
   setIsLoading: (state, { isLoading }) => {
     state.isLoading = isLoading
@@ -535,8 +543,9 @@ export const actions: DefineActions<
 
       await categorize(categorizeRequest)
       commit('uncheckStock', {})
-      // TODO カテゴライズされたストック一覧を表示する機能を作成する際に対応する
-      // commit("removeCategorizedStocks", categorizePayload.stockArticleIds);
+      commit('removeCategorizedStocks', {
+        stockArticleIds: categorizePayload.stockArticleIds
+      })
       commit('updateStockCategory', {
         stockArticleIds: categorizePayload.stockArticleIds,
         category: categorizePayload.category


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/39

# Doneの定義
表題の通り

# 変更点概要

## 技術的変更点概要
カテゴライズされたストックを表示する機能を作成。

カテゴリが選択された際に、`stocks/categories/_id`へルーティングし、`app/pages/stocks/categories/_id.vue`コンポーネントのfetch関数で、カテゴライズされたストック一覧取得するAPIへのリクエストを行なっている。

また、カテゴリ一覧の取得をページコンポーネントのfetch関数で取得していたが、`全てのストック一覧`、またはカテゴリを選択する度にAPIへリクエストされてしまうため、処理を移動。
コンポーネントのcreated関数で、カテゴリが取得されていない場合のみカテゴリ取得APIへのリクエストを行うように修正した。
https://github.com/nekochans/qiita-stocker-nuxt/pull/67/files#diff-8125abe6b8d9133ce8f9051507279ad2L22

# 補足情報
サイドメニューの`全てのカテゴリ`を選択時の動作については未対応。
別の課題にて対応する。
