### PR TITLE
サイドメニューの全てのストック押下時の表示処理を追加

### DIFF
--- a/app/components/Category.vue
+++ b/app/components/Category.vue
@@ -136,7 +136,7 @@ export default class extends Vue {
     this.$emit('clickDestroyCategory', this.category.categoryId)
 
     if (this.isSelecting) {
-      this.$router.push({ path: `/stocks/all` })
+      this.$router.push({ path: '/stocks/all' })
     }
   }
 

--- a/app/components/DefaultMenuList.vue
+++ b/app/components/DefaultMenuList.vue
@@ -20,7 +20,7 @@ export default class extends Vue {
 
   handleClick() {
     this.$emit('clickStocksAll')
-    this.$router.push({ path: `/stocks/all` })
+    this.$router.push({ path: '/stocks/all' })
   }
 
   isSelecting() {

--- a/app/components/DefaultMenuList.vue
+++ b/app/components/DefaultMenuList.vue
@@ -19,7 +19,8 @@ export default class extends Vue {
   displayCategoryId!: number
 
   handleClick() {
-    // TODO 全てのストックを選択時の処理を作成
+    this.$emit('clickStocksAll')
+    this.$router.push({ path: `/stocks/all` })
   }
 
   isSelecting() {

--- a/app/components/SideMenu.vue
+++ b/app/components/SideMenu.vue
@@ -1,6 +1,9 @@
 <template>
   <aside class="submenu menu">
-    <DefaultMenuList :display-category-id="displayCategoryId" />
+    <DefaultMenuList
+      :display-category-id="displayCategoryId"
+      @clickStocksAll="onClickStocksAll"
+    />
     <CategoryList
       :categories="categories"
       @clickUpdateCategory="onClickUpdateCategory"
@@ -47,6 +50,10 @@ export default class extends Vue {
 
   onClickDestroyCategory(categoryId: number) {
     this.$emit('clickDestroyCategory', categoryId)
+  }
+
+  onClickStocksAll() {
+    this.$emit('clickStocksAll')
   }
 }
 </script>

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -99,7 +99,8 @@ import { Page, Category, UncategorizedStock } from '@/domain/domain'
       'destroyCategory',
       'setIsCategorizing',
       'categorize',
-      'checkStock'
+      'checkStock',
+      'resetData'
     ])
   }
 })
@@ -112,12 +113,13 @@ export default class extends Vue {
   setIsCategorizing!: () => void
   categorize!: (categorizePayload: CategorizePayload) => void
   checkStock!: (stock: UncategorizedStock) => void
+  resetData!: () => void
 
   checkedStockArticleIds!: string[]
   categories!: Category[]
 
   onClickCategory() {
-    // 全てのストックが選択されている場合は何もしない
+    this.resetData()
   }
 
   async fetchOtherPageStock(page: Page) {
@@ -198,8 +200,7 @@ export default class extends Vue {
   }
 
   onClickStocksAll() {
-    // TODO 全てのストック選択時の動作を追加
-    // this.resetData()
+    this.resetData()
   }
 
   async initializeCategory() {

--- a/app/components/pages/stocks/all.vue
+++ b/app/components/pages/stocks/all.vue
@@ -29,7 +29,6 @@
             v-show="!isLoading"
             :stocks="uncategorizedStocks"
             :is-categorizing="isCategorizing"
-            :is-loading="isLoading"
             @clickCheckStock="onClickCheckStock"
           />
           <Pagination

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -217,8 +217,7 @@ export default class extends Vue {
   }
 
   onClickStocksAll() {
-    // TODO 全てのストック選択時の動作を追加
-    // this.resetData()
+    this.resetData()
   }
 
   async initializeCategory() {

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -123,6 +123,7 @@ export default class extends Vue {
 
   checkedCategorizedStockArticleIds!: string[]
   categories!: Category[]
+  displayCategoryId!: number
 
   onClickCategory() {
     this.resetData()
@@ -194,18 +195,21 @@ export default class extends Vue {
     this.checkStock(stock)
   }
 
-  fetchOtherPageStock(page: Page) {
-    console.log(`${page} fetchOtherPageStock`)
-    // try {
-    //   await this.fetchUncategorizedStocks(page)
-    // } catch (error) {
-    //   this.$router.push({
-    //     name: 'original_error',
-    //     params: {
-    //       message: error.message
-    //     }
-    //   })
-    // }
+  async fetchOtherPageStock(page: Page) {
+    try {
+      const fetchCategorizedStockPayload = {
+        page,
+        categoryId: this.displayCategoryId
+      }
+      await this.fetchCategorizedStock(fetchCategorizedStockPayload)
+    } catch (error) {
+      this.$router.push({
+        name: 'original_error',
+        params: {
+          message: error.message
+        }
+      })
+    }
   }
 
   onSetIsCategorizing() {

--- a/app/pages/stocks/all.vue
+++ b/app/pages/stocks/all.vue
@@ -19,6 +19,7 @@ export default class extends Vue {
   async fetch({ store, error }: NuxtContext) {
     try {
       await store.dispatch('qiita/fetchUncategorizedStocks')
+      await store.dispatch('qiita/saveDisplayCategoryId', 0)
     } catch (e) {
       error({
         statusCode: e.code,

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -326,7 +326,6 @@ export const mutations: DefineMutations<QiitaMutations, QiitaState> = {
   resetData: state => {
     state.isCategorizing = false
     state.isCancelingCategorization = false
-    state.displayCategoryId = 0
     state.currentPage = 1
   }
 }
@@ -523,7 +522,10 @@ export const actions: DefineActions<
       commit('removeCategory', categoryId)
       commit('removeCategoryFromStock', categoryId)
 
-      if (state.displayCategoryId === categoryId) return commit('resetData', {})
+      if (state.displayCategoryId === categoryId) {
+        commit('saveDisplayCategoryId', { categoryId: 0 })
+        commit('resetData', {})
+      }
     } catch (error) {
       return Promise.reject(error)
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/70

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/70 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
全てのストックが押下された際に、`stocks/all` に遷移し、全てのストックを表示。
また、カテゴライズされたストック一覧画面を表示した際のページング処理が未実装であったため、処理を追加している。

## 技術的変更点概要
下記の動作を回避するため、`state. displayCategoryId`の更新処理をactionの`resetData`が呼ばれたタイミングから、ページコンポーネントの`fetch`関数が実行されたタイミングに移動。

現像：サイドメニューの異なるカテゴリーを連続で選択した場合、一瞬だけ`全てのストック`が選択状態のスタイルになった後に、押下したカテゴリが選択状態のスタイルになる

# 補足情報
ストック一覧を表示する際に、`ストック一覧を取得中...`のメッセージが表示された後に、一瞬だけ　`ストックされた記事はありません。`が表示されてしまう。表示されないように制御しようとしたが簡単に修正できなかったので、別の課題で対応する。
