### PR TITLE
セッション無効時のエラー処理を追加

### DIFF
--- a/app/middleware/redirect.ts
+++ b/app/middleware/redirect.ts
@@ -4,7 +4,8 @@ export default function({ store, redirect, route }: any) {
     '/signup',
     '/privacy',
     '/terms',
-    '/cancel/complete'
+    '/cancel/complete',
+    '/error'
   ]
 
   if (notRequiredAuthorization.includes(route.path)) return

--- a/app/store/qiita.ts
+++ b/app/store/qiita.ts
@@ -355,6 +355,9 @@ export const actions: DefineActions<
       await cancelAccount()
       commit('saveSessionId', { sessionId: '' })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -392,6 +395,9 @@ export const actions: DefineActions<
       commit('savePaging', { paging: response.paging })
       commit('saveCurrentPage', { currentPage: page.page })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       commit('setIsLoading', { isLoading: false })
       return Promise.reject(error)
     }
@@ -438,6 +444,9 @@ export const actions: DefineActions<
       commit('saveCurrentPage', { currentPage: payload.page.page })
       commit('setIsLoading', { isLoading: false })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       commit('setIsLoading', { isLoading: false })
       return Promise.reject(error)
     }
@@ -447,6 +456,9 @@ export const actions: DefineActions<
       await logout()
       commit('saveSessionId', { sessionId: '' })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -469,6 +481,9 @@ export const actions: DefineActions<
 
       commit('addCategory', savedCategory)
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -485,6 +500,9 @@ export const actions: DefineActions<
 
       commit('saveCategories', { categories })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -514,6 +532,9 @@ export const actions: DefineActions<
         name: updateCategoryResponse.name
       })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -538,6 +559,9 @@ export const actions: DefineActions<
         commit('resetData', {})
       }
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -569,6 +593,9 @@ export const actions: DefineActions<
         category: categorizePayload.category
       })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -586,6 +613,9 @@ export const actions: DefineActions<
       await cancelCategorization(cancelCategorizationRequest)
       commit('removeCategorizedStocksById', { categorizedStockId })
     } catch (error) {
+      if (isUnauthorized(error.code)) {
+        commit('saveSessionId', { sessionId: '' })
+      }
       return Promise.reject(error)
     }
   },
@@ -613,3 +643,7 @@ export const {
   QiitaMutations,
   QiitaActions
 >('qiita')
+
+const isUnauthorized = (statusCode: number): boolean => {
+  return statusCode === 401
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/49

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/49 の完了条件が満たされていること

# スクリーンショット
<img width="1423" alt="スクリーンショット 2019-09-16 18 19 31" src="https://user-images.githubusercontent.com/32682645/64946860-c4d95f80-d8ae-11e9-914f-edec29e9013d.png">

# 変更点概要

## 仕様的変更点概要
BackendAPIからセッションエラーが返って場合、エラー画面を表示する処理を追加。

## 技術的変更点概要
BackendAPIから401が帰ってきた場合、stateに保持しているセッションIDを削除し、エラー画面を表示する処理をactionに追加。
また、エラー画面が認証情報がなくても表示できるようにミドルウェア`app/middleware/redirect.ts`を修正。