### PR TITLE
ヘッダーのストック一覧を選択した際のリセット処理を追加する

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -25,8 +25,8 @@
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">メニュー</a>
               <div class="navbar-dropdown is-right">
-                <nuxt-link class="navbar-item" to="/stocks/all"
-                  >ストック一覧</nuxt-link
+                <a class="navbar-item" @click="onClickStocksAll"
+                  >ストック一覧</a
                 >
                 <a class="navbar-item" @click="logout">ログアウト</a>
               </div>
@@ -44,19 +44,31 @@ import { mapGetters, mapActions } from '@/store/qiita'
 
 @Component({
   computed: {
-    ...mapGetters(['isLoggedIn'])
+    ...mapGetters(['isLoggedIn', 'displayCategoryId'])
   },
   methods: {
-    ...mapActions(['logoutAction'])
+    ...mapActions(['logoutAction', 'resetData'])
   }
 })
 export default class AppHeader extends Vue {
   logoutAction!: () => void
+  resetData!: () => void
 
+  displayCategoryId!: number
   isMenuActive: boolean = false
 
   menuToggle() {
     this.isMenuActive = !this.isMenuActive
+  }
+
+  onClickStocksAll() {
+    if (this.isSelecting()) return
+    this.resetData()
+    this.$router.push({ path: '/stocks/all' })
+  }
+
+  isSelecting() {
+    return this.displayCategoryId === 0
   }
 
   async logout() {

--- a/app/components/DefaultMenuList.vue
+++ b/app/components/DefaultMenuList.vue
@@ -19,6 +19,7 @@ export default class extends Vue {
   displayCategoryId!: number
 
   handleClick() {
+    if (this.isSelecting()) return
     this.$emit('clickStocksAll')
     this.$router.push({ path: '/stocks/all' })
   }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/75

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/75 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
サイドメニューの`全てのストック`とヘッダーの`ストック一覧`を選択した際の動作が同じになるように下記の修正を行なった。

- ヘッダーの`ストック一覧`を選択した際のリセット処理を追加
- 全てのストックが表示されている場合は、ヘッダーの `ストック一覧`が選択されても何もしないように修正
- サイドメニューの`全てのストック`を連打しが場合、`ストックされた記事はありません。`と表示されてしまっていたので、  全てのストックが表示されている場合は、`全てのストック`を選択した際に何もしないように修正

## 技術的変更点概要
全てのストックが表示されているかどうかは、stateの`displayCategoryId`から判定している。

