### PR TITLE
BFFの認証処理のエラー処理を追加

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -56,19 +56,20 @@ export default class AppHeader extends Vue {
 
   displayCategoryId!: number
   isMenuActive: boolean = false
+  isSelectingStocksAll: boolean = false
 
   menuToggle() {
     this.isMenuActive = !this.isMenuActive
   }
 
   onClickStocksAll() {
-    if (this.isSelecting()) return
+    if (this.isSelectingStocksAll) return
     this.resetData()
     this.$router.push({ path: '/stocks/all' })
   }
 
-  isSelecting() {
-    return this.displayCategoryId === 0
+  created() {
+    this.isSelectingStocksAll = this.$route.path === '/stocks/all'
   }
 
   async logout() {

--- a/app/pages/error.vue
+++ b/app/pages/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <Error :message="message" />
+  <Error :message="displayMessage" />
 </template>
 
 <script lang="ts">
@@ -14,5 +14,16 @@ import Error from '@/components/pages/error.vue'
 export default class extends Vue {
   @Prop()
   message!: string
+
+  displayMessage: string = ''
+
+  created() {
+    if (this.message) {
+      this.displayMessage = this.message
+    } else {
+      this.displayMessage =
+        'エラーが発生しました。TOPページより再度行なってください。'
+    }
+  }
 }
 </script>

--- a/server/auth/oauth.ts
+++ b/server/auth/oauth.ts
@@ -42,27 +42,16 @@ router.get('/callback', async (req: Request, res: Response) => {
     req.cookies[auth.COOKIE_AUTH_STATE] == null ||
     req.cookies[auth.COOKIE_AUTH_STATE] !== req.query.state
   ) {
-    return res
-      .status(400)
-      .send()
-      .end()
+    return res.redirect(auth.redirectAppErrorUrl())
   }
 
-  if (req.query.code == null) {
-    return res
-      .status(400)
-      .send()
-      .end()
-  }
+  if (req.query.code == null) return res.redirect(auth.redirectAppErrorUrl())
 
   if (
     req.cookies[auth.COOKIE_ACCOUNT_ACTION] !== 'signUp' &&
     req.cookies[auth.COOKIE_ACCOUNT_ACTION] !== 'login'
   ) {
-    return res
-      .status(400)
-      .send()
-      .end()
+    return res.redirect(auth.redirectAppErrorUrl())
   }
 
   try {
@@ -79,10 +68,7 @@ router.get('/callback', async (req: Request, res: Response) => {
 
     return res.redirect(auth.redirectAppUrl())
   } catch (error) {
-    return res
-      .status(400)
-      .send()
-      .end()
+    return res.redirect(auth.redirectAppErrorUrl())
   }
 })
 

--- a/server/domain/auth.ts
+++ b/server/domain/auth.ts
@@ -99,6 +99,10 @@ export const redirectAppUrl = (): string => {
   return `${appUrl()}/stocks/all`
 }
 
+export const redirectAppErrorUrl = (): string => {
+  return `${appUrl()}/error`
+}
+
 /**
  * @param authorizationCode
  * @param accountAction


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/48

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/48 の完了条件が満たされていること

# スクリーンショット
<img width="1432" alt="スクリーンショット 2019-09-22 15 10 06" src="https://user-images.githubusercontent.com/32682645/65383360-909eec80-dd4f-11e9-824d-e25deb59c0dd.png">

# 変更点概要

## 仕様的変更点概要
BFFでエラーが発生(アカウント登録、ログインに失敗)した場合、エラー画面を表示する処理を追加。
エラーメッセージ：`エラーが発生しました。TOPページより再度行なってください。`

## 技術的変更点概要
新規でエラーページを作成するのではなく、既存のエラーページを表示するエラーページコンポーネント`app/pages/error.vue`に、エラーメッセージを追加。
BFFでエラーが発生した場合は、上記のページにリダイレクトしている。

また、ヘッダーメニューの`ストック一覧`を押下した際に下記の不具合が発生していたため合わせて修正。

**事象**：トップページを表示中に、ヘッダーメニューの`ストック一覧`を押下した場合、ストック一覧ページに遷移しない。

**原因**：ストック一覧を表示しているかどうかの判定条件が不正。ストック一覧が表示されていなくても、ストック一覧が表示されていると判定されていた。

**対応内容**：URLのPathを取得し、ストック一覧ページが表示されているかどうかを判定するように変更。
