### PR TITLE
カテゴライズ解除時のストック一覧の表示処理を修正

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -44,7 +44,7 @@ import { mapGetters, mapActions } from '@/store/qiita'
 
 @Component({
   computed: {
-    ...mapGetters(['isLoggedIn', 'displayCategoryId'])
+    ...mapGetters(['isLoggedIn'])
   },
   methods: {
     ...mapActions(['logoutAction', 'resetData'])
@@ -54,7 +54,6 @@ export default class AppHeader extends Vue {
   logoutAction!: () => void
   resetData!: () => void
 
-  displayCategoryId!: number
   isMenuActive: boolean = false
   isSelectingStocksAll: boolean = false
 

--- a/app/components/pages/stocks/categories/stockCategories.vue
+++ b/app/components/pages/stocks/categories/stockCategories.vue
@@ -127,6 +127,8 @@ export default class extends Vue {
   checkedCategorizedStockArticleIds!: string[]
   categories!: Category[]
   displayCategoryId!: number
+  currentPage!: number
+  categorizedStocks!: CategorizedStock[]
 
   onClickCategory() {
     this.resetData()
@@ -191,6 +193,14 @@ export default class extends Vue {
   async onClickCancelCategorization(categorizedStockId: number) {
     try {
       await this.cancelCategorization(categorizedStockId)
+      if (!this.categorizedStocks.length && this.currentPage !== 1) {
+        this.resetData()
+        const fetchCategorizedStockPayload = {
+          page: { page: 0, perPage: 0, relation: '' },
+          categoryId: this.displayCategoryId
+        }
+        await this.fetchCategorizedStock(fetchCategorizedStockPayload)
+      }
     } catch (error) {
       this.$router.push({
         name: 'original_error',


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/76

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/76 の完了条件が満たされていること

# 変更点概要

## 技術的変更点概要
カテゴリ選択中に2ページ以降を表示し、その画面に表示された全てのストックのカテゴライズを解除した場合、1ページ目が表示されるように動作を修正。