### PR TITLE
BFF以外で発生したエラーはLayoutプロパティで作成したエラーページを表示する

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -76,11 +76,9 @@ export default class AppHeader extends Vue {
       await this.logoutAction()
       this.$router.replace({ path: '/' })
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }

--- a/app/components/pages/cancel/Index.vue
+++ b/app/components/pages/cancel/Index.vue
@@ -27,11 +27,9 @@ export default class extends Vue {
       await this.cancelAction()
       this.$router.replace({ path: 'cancel/complete' })
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }

--- a/app/components/pages/stocks/All.vue
+++ b/app/components/pages/stocks/All.vue
@@ -128,11 +128,9 @@ export default class extends Vue {
       await this.fetchUncategorizedStocks(page)
       this.setIsLoadingAction(false)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -141,11 +139,9 @@ export default class extends Vue {
     try {
       await this.saveCategory(categoryName)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -154,11 +150,9 @@ export default class extends Vue {
     try {
       await this.updateCategory(updateCategoryPayload)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -167,11 +161,9 @@ export default class extends Vue {
     try {
       await this.destroyCategory(categoryId)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -192,11 +184,9 @@ export default class extends Vue {
       }
       await this.categorize(categorizePayload)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -209,11 +199,9 @@ export default class extends Vue {
     try {
       await this.fetchCategory()
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }

--- a/app/components/pages/stocks/categories/StockCategories.vue
+++ b/app/components/pages/stocks/categories/StockCategories.vue
@@ -140,11 +140,9 @@ export default class extends Vue {
     try {
       await this.saveCategory(categoryName)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -153,11 +151,9 @@ export default class extends Vue {
     try {
       await this.updateCategory(updateCategoryPayload)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -166,11 +162,9 @@ export default class extends Vue {
     try {
       await this.destroyCategory(categoryId)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -183,11 +177,9 @@ export default class extends Vue {
       }
       await this.categorize(categorizePayload)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -204,11 +196,9 @@ export default class extends Vue {
         await this.fetchCategorizedStock(fetchCategorizedStockPayload)
       }
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -226,11 +216,9 @@ export default class extends Vue {
       await this.fetchCategorizedStock(fetchCategorizedStockPayload)
       this.setIsLoadingAction(false)
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }
@@ -251,11 +239,9 @@ export default class extends Vue {
     try {
       await this.fetchCategory()
     } catch (error) {
-      this.$router.push({
-        name: 'original_error',
-        params: {
-          message: error.message
-        }
+      return this.$nuxt.error({
+        statusCode: error.code,
+        message: error.message
       })
     }
   }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/89

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/89 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
BFF以外で発生したエラーはLayoutプロパティで作成したエラーページを表示するように変更。
今までは、`/error`に遷移していたが、ルーティングの遷移は行わずにエラーページが表示される。
エラーページの見た目には変更は無い。