### PR TITLE
バイナリメディアタイプの設定を削除する

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "express": "^4.17.1",
     "nuxt": "^2.10.0",
     "nuxt-property-decorator": "^2.3.0",
-    "serverless-apigw-binary": "^0.4.4",
     "universal-cookie": "^4.0.2",
     "uuid": "^3.3.2",
     "vuex-type-helper": "^1.2.2"

--- a/server/lambda.ts
+++ b/server/lambda.ts
@@ -2,31 +2,7 @@ import lambda from 'aws-lambda'
 import awsServerlessExpress from 'aws-serverless-express'
 import app from './app'
 
-const binaryMimeTypes = [
-  'application/javascript',
-  'application/json',
-  'application/octet-stream',
-  'application/xml',
-  'font/eot',
-  'font/opentype',
-  'font/otf',
-  'image/jpeg',
-  'image/png',
-  'image/svg+xml',
-  'text/comma-separated-values',
-  'text/css',
-  'text/html',
-  'text/javascript',
-  'text/plain',
-  'text/text',
-  'text/xml'
-]
-
-const server = awsServerlessExpress.createServer(
-  app,
-  undefined,
-  binaryMimeTypes
-)
+const server = awsServerlessExpress.createServer(app)
 
 module.exports.render = (
   event: lambda.APIGatewayEvent,

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,13 +28,7 @@ provider:
     TRACKING_ID: ${env:TRACKING_ID}
 
 plugins:
-  - serverless-apigw-binary
   - serverless-plugin-warmup
-
-custom:
-  apigwBinary:
-    types:
-      - '*/*'
 
 package:
   individually: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -11215,11 +11215,6 @@ server-destroy@^1.0.1:
   resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
   integrity sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=
 
-serverless-apigw-binary@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/serverless-apigw-binary/-/serverless-apigw-binary-0.4.4.tgz#f3cffd8365322a2a1d8bde5fd94b306b7a64d4fb"
-  integrity sha512-2DJmQTzeXa/+8u9ekReqf7j4gQjBtzQE4MK9nlOnEz4F7MVWCQXYlLPmf2TXSoxxJZzlWvIiNzCTq6vAT9F5FQ==
-
 serverless-plugin-warmup@^4.7.0-rc.1:
   version "4.7.0-rc.1"
   resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-4.7.0-rc.1.tgz#92682b56605118fd41dda2b8b881ca2f44ab6dcd"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-nuxt/issues/93

# Doneの定義
https://github.com/nekochans/qiita-stocker-nuxt/issues/93 の完了の定義を満たしていること

# 変更点概要

## 技術的変更点概要
バイナリメディアタイプの対応している箇所を削除。
不要な設定を削除しただけなので、動作への影響はなし。